### PR TITLE
feat(skill): add kocao-agent management skill for AI coding tools

### DIFF
--- a/.opencode/skills/kocao-agent/SKILL.md
+++ b/.opencode/skills/kocao-agent/SKILL.md
@@ -1,112 +1,121 @@
 ---
 name: kocao-agent
 description: |
-    Manage remote Kocao sandbox agents (workspace sessions) via the kocao CLI.
-    Use when: starting an agent on the cluster, managing remote agents, running
-    codex/claude/opencode remotely, listing running agents, sending a task to a
-    remote agent, checking agent status, stopping a remote agent, streaming agent
-    logs, or attaching to a running session.
+    Manage remote Kocao workspace sessions from an AI assistant.
+    Use when: listing remote sessions, creating a new session, checking session
+    status, viewing logs, stopping a session, or sending a prompt through the
+    experimental exec endpoint when the control-plane supports it.
 ---
 
-Manage remote Kocao coding-agent sandbox sessions from an AI assistant context.
+Manage remote Kocao workspace sessions from an AI assistant context.
 
-The `kocao` CLI communicates with the Kocao control-plane API to create, inspect,
-and control workspace sessions that run coding agents in ephemeral Kubernetes pods.
+The `kocao` CLI communicates with the Kocao control-plane API to create,
+inspect, and control workspace sessions that run inside ephemeral Kubernetes
+pods. This skill wraps the common session-management actions in small shell
+scripts with consistent output and error handling.
 
 ## Prerequisites
 
-- `kocao` binary in PATH (see `reference/agents.md` for install)
-- `KOCAO_API_URL` and `KOCAO_TOKEN` environment variables set (or a config file at `~/.config/kocao/settings.json`)
+- `kocao` binary in `PATH` for list/status/logs workflows
+- `curl` and `jq` for the API-backed helper scripts
+- `KOCAO_API_URL` and `KOCAO_TOKEN` environment variables set, or a config file at `~/.config/kocao/settings.json`
 - Cluster deployed and agent secrets seeded (`seed-agent-secrets`)
 
 ## Quick Reference
 
-| Action | Script | CLI equivalent |
+| Action | Script | Backing capability |
 |---|---|---|
 | List sessions | `scripts/agent-list.sh` | `kocao sessions ls --json` |
-| Start/create session | `scripts/agent-start.sh` | (via control-plane API — see workflow) |
+| Create session | `scripts/agent-start.sh` | `POST /api/v1/workspace-sessions` |
 | Get session details | `scripts/agent-status.sh` | `kocao sessions status <id> --json` |
-| Stream logs | `scripts/agent-logs.sh` | `kocao sessions logs <id> --json` |
-| Execute/send task | `scripts/agent-exec.sh` | `kocao sessions attach <id> --driver` |
-| Stop a session | `scripts/agent-stop.sh` | (via control-plane API — see workflow) |
+| Fetch logs | `scripts/agent-logs.sh` | `kocao sessions logs <id> ...` |
+| Send a prompt | `scripts/agent-exec.sh` | Experimental `POST /api/v1/workspace-sessions/<id>/exec` |
+| Stop a session | `scripts/agent-stop.sh` | `DELETE /api/v1/workspace-sessions/<id>` |
+
+## Script Conventions
+
+All scripts now follow the same shape:
+
+- `--help` prints a concise usage block
+- usage problems exit with code `2`
+- API/runtime failures exit with code `1`
+- JSON is the default output unless `--no-json` says otherwise
+- API scripts reuse `scripts/common.sh` for dependency checks, URL encoding, and HTTP error formatting
 
 ## Workflows
 
 ### 1. List running agents
 
-List all workspace sessions to see what agents are active.
+List all workspace sessions to see what is active.
 
 ```bash
 scripts/agent-list.sh
 ```
 
-Parse the JSON output to show session IDs, names, phases, and creation times.
-Filter by phase `Running` to find active agents.
+Filter the JSON output by `.workspaceSessions[] | select(.phase == "Running")`
+to find active sessions.
 
 ### 2. Check agent status
 
-Get detailed status for a specific workspace session, including its current
-harness run, pod name, and phase.
+Get the current session phase plus the latest harness-run details.
 
 ```bash
 scripts/agent-status.sh <session-id>
 ```
 
-The response includes:
-- Session phase (Pending, Running, Succeeded, Failed)
-- Active harness run ID and phase
-- Pod name (for logs/debugging)
+The JSON response includes:
+- session ID, display name, phase, and repo URL
+- current harness run ID and phase (when present)
+- pod name for debugging/log lookup
 
 ### 3. Stream agent logs
 
-Fetch recent log output from an agent's pod.
+Fetch recent log output from the active harness pod.
 
 ```bash
-# Last 200 lines (default)
-scripts/agent-logs.sh <session-id>
+# JSON one-shot fetch
+scripts/agent-logs.sh <session-id> --tail 200
 
-# Last 50 lines
-scripts/agent-logs.sh <session-id> --tail 50
+# Plain text
+scripts/agent-logs.sh <session-id> --tail 50 --no-json
 
-# Follow mode (continuous polling)
-scripts/agent-logs.sh <session-id> --follow
+# Follow mode
+scripts/agent-logs.sh <session-id> --follow --no-json
 ```
 
-Note: `--follow` and `--json` cannot be combined. Use `--json` for structured
-one-shot fetches; omit it when following.
+`--follow` and `--json` are mutually exclusive.
 
-### 4. Send a task to a remote agent (exec/attach)
+### 4. Create a remote session
 
-Attach to a running session in driver mode to send input.
+Create a new workspace session for a repository.
 
 ```bash
-scripts/agent-exec.sh <session-id> --prompt "Review PR #42 and suggest improvements"
+scripts/agent-start.sh --repo https://github.com/org/repo --agent codex
 ```
 
-This attaches in driver mode, sends the prompt text, then detaches.
-For interactive sessions, use `kocao sessions attach <id> --driver` directly.
+Important details:
+- `--repo` is required
+- `--agent` currently acts as a **display-name label only** (`opencode`, `codex`, `claude`, `pi`)
+- the control-plane API creates a generic session; it does **not** switch images or runtime behavior based on `--agent`
+- by default the script waits for `Running` and then prints the final status JSON
+- `--quiet` prints just the session ID for shell pipelines
 
-**Important:** `attach` requires an interactive TTY for full bidirectional I/O.
-The `agent-exec.sh` script provides a fire-and-forget prompt delivery mode
-suitable for AI assistant use.
+### 5. Send a task to a remote session
 
-### 5. Start a remote agent
-
-Start a new workspace session. This is typically done through the control-plane
-API or UI. The script wraps the session creation flow.
+Send a prompt through the control-plane exec endpoint when that endpoint exists.
 
 ```bash
-scripts/agent-start.sh --repo https://github.com/org/repo --agent opencode
+scripts/agent-exec.sh <session-id> --prompt "Review PR #42 and summarize the risks"
 ```
 
-Supported `--agent` values: `opencode`, `codex`, `claude`, `pi`
+If the API returns HTTP 404, the control-plane does not expose the exec
+endpoint yet. In that case, use an interactive terminal instead:
 
-The script will:
-1. Call the control-plane API to create a workspace session
-2. Wait for the session to reach `Running` phase
-3. Output the session ID in JSON format
+```bash
+kocao sessions attach <session-id> --driver
+```
 
-### 6. Stop a remote agent
+### 6. Stop a remote session
 
 Stop/terminate a workspace session.
 
@@ -114,26 +123,18 @@ Stop/terminate a workspace session.
 scripts/agent-stop.sh <session-id>
 ```
 
-This requests graceful termination of the session's harness run.
-
-### 7. Multi-agent workflow
-
-Start multiple agents and distribute tasks:
+### 7. Multi-session workflow
 
 ```bash
-# Start agents
 session1=$(scripts/agent-start.sh --repo https://github.com/org/repo --agent opencode --quiet)
 session2=$(scripts/agent-start.sh --repo https://github.com/org/repo --agent codex --quiet)
 
-# Send tasks
 scripts/agent-exec.sh "$session1" --prompt "Implement the auth module"
 scripts/agent-exec.sh "$session2" --prompt "Write tests for the API endpoints"
 
-# Monitor
 scripts/agent-status.sh "$session1"
 scripts/agent-status.sh "$session2"
 
-# Collect logs
 scripts/agent-logs.sh "$session1" --tail 50
 scripts/agent-logs.sh "$session2" --tail 50
 ```
@@ -144,68 +145,38 @@ For managed multi-agent orchestration driven by GitHub Projects, use the
 `kocao symphony` commands directly:
 
 ```bash
-kocao symphony ls --json          # List symphony projects
-kocao symphony get <name> --json  # Get project details
-kocao symphony create --file <path> --json  # Create from spec
-kocao symphony pause <name>       # Pause processing
-kocao symphony resume <name>      # Resume processing
-kocao symphony refresh <name>     # Force re-sync
+kocao symphony ls --json
+kocao symphony get <name> --json
+kocao symphony create --file <path> --json
+kocao symphony pause <name>
+kocao symphony resume <name>
+kocao symphony refresh <name>
 ```
 
-## Usage Examples
+## Example Triggers
 
-**User:** "Start a codex agent on the cluster to work on this repo"
-```
-scripts/agent-start.sh --repo https://github.com/withakay/kocao --agent codex
-```
+Use this skill for prompts like:
 
-**User:** "What agents are running?"
-```
-scripts/agent-list.sh
-```
-
-**User:** "Check on agent abc-123"
-```
-scripts/agent-status.sh abc-123
-```
-
-**User:** "Show me the logs for that agent"
-```
-scripts/agent-logs.sh abc-123 --tail 100
-```
-
-**User:** "Ask the remote agent to review this PR"
-```
-scripts/agent-exec.sh abc-123 --prompt "Review PR #42"
-```
-
-**User:** "Stop all agents"
-```
-# List all, then stop each
-for id in $(scripts/agent-list.sh | jq -r '.workspaceSessions[] | select(.phase == "Running") | .id'); do
-  scripts/agent-stop.sh "$id"
-done
-```
-
-**User:** "Stream the agent's output"
-```
-scripts/agent-logs.sh abc-123 --follow
-```
+- “What Kocao sessions are running right now?”
+- “Start a remote session for this repo and wait until it is running.”
+- “Check the status of session `ws-123`.”
+- “Show the last 100 lines from that agent session.”
+- “Stop the finished session.”
+- “Send this prompt to the remote session if exec is supported.”
 
 ## Environment Variables
 
 | Variable | Description | Required |
 |---|---|---|
-| `KOCAO_API_URL` | Control-plane API base URL | Yes (or config file) |
-| `KOCAO_TOKEN` | Bearer token for authentication | Yes (or config file) |
-| `KOCAO_TIMEOUT` | HTTP request timeout (e.g. `30s`) | No (default: 15s) |
-| `KOCAO_VERBOSE` | Enable debug output (`true`/`false`) | No |
+| `KOCAO_API_URL` | Control-plane API base URL | Yes for API-backed scripts unless config is used |
+| `KOCAO_TOKEN` | Bearer token for authentication | Yes for API-backed scripts unless config is used |
+| `KOCAO_TIMEOUT` | HTTP request timeout for the CLI | No |
+| `KOCAO_VERBOSE` | Enable CLI debug output | No |
 
 ## Error Handling
 
-All scripts exit with meaningful codes:
 - `0` — success
-- `1` — API/runtime error (check stderr for details)
-- `2` — usage error (bad arguments, missing binary)
+- `1` — API or runtime error
+- `2` — usage error or missing dependency
 
-Common errors and fixes are documented in `reference/agents.md`.
+See `reference/agents.md` for setup notes and troubleshooting.

--- a/.opencode/skills/kocao-agent/SKILL.md
+++ b/.opencode/skills/kocao-agent/SKILL.md
@@ -44,6 +44,8 @@ All scripts now follow the same shape:
 
 ## Workflows
 
+> **Note:** All script paths below are relative to `.opencode/skills/kocao-agent/`.
+
 ### 1. List running agents
 
 List all workspace sessions to see what is active.

--- a/.opencode/skills/kocao-agent/SKILL.md
+++ b/.opencode/skills/kocao-agent/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: kocao-agent
+description: |
+    Manage remote Kocao sandbox agents (workspace sessions) via the kocao CLI.
+    Use when: starting an agent on the cluster, managing remote agents, running
+    codex/claude/opencode remotely, listing running agents, sending a task to a
+    remote agent, checking agent status, stopping a remote agent, streaming agent
+    logs, or attaching to a running session.
+---
+
+Manage remote Kocao coding-agent sandbox sessions from an AI assistant context.
+
+The `kocao` CLI communicates with the Kocao control-plane API to create, inspect,
+and control workspace sessions that run coding agents in ephemeral Kubernetes pods.
+
+## Prerequisites
+
+- `kocao` binary in PATH (see `reference/agents.md` for install)
+- `KOCAO_API_URL` and `KOCAO_TOKEN` environment variables set (or a config file at `~/.config/kocao/settings.json`)
+- Cluster deployed and agent secrets seeded (`seed-agent-secrets`)
+
+## Quick Reference
+
+| Action | Script | CLI equivalent |
+|---|---|---|
+| List sessions | `scripts/agent-list.sh` | `kocao sessions ls --json` |
+| Start/create session | `scripts/agent-start.sh` | (via control-plane API — see workflow) |
+| Get session details | `scripts/agent-status.sh` | `kocao sessions status <id> --json` |
+| Stream logs | `scripts/agent-logs.sh` | `kocao sessions logs <id> --json` |
+| Execute/send task | `scripts/agent-exec.sh` | `kocao sessions attach <id> --driver` |
+| Stop a session | `scripts/agent-stop.sh` | (via control-plane API — see workflow) |
+
+## Workflows
+
+### 1. List running agents
+
+List all workspace sessions to see what agents are active.
+
+```bash
+scripts/agent-list.sh
+```
+
+Parse the JSON output to show session IDs, names, phases, and creation times.
+Filter by phase `Running` to find active agents.
+
+### 2. Check agent status
+
+Get detailed status for a specific workspace session, including its current
+harness run, pod name, and phase.
+
+```bash
+scripts/agent-status.sh <session-id>
+```
+
+The response includes:
+- Session phase (Pending, Running, Succeeded, Failed)
+- Active harness run ID and phase
+- Pod name (for logs/debugging)
+
+### 3. Stream agent logs
+
+Fetch recent log output from an agent's pod.
+
+```bash
+# Last 200 lines (default)
+scripts/agent-logs.sh <session-id>
+
+# Last 50 lines
+scripts/agent-logs.sh <session-id> --tail 50
+
+# Follow mode (continuous polling)
+scripts/agent-logs.sh <session-id> --follow
+```
+
+Note: `--follow` and `--json` cannot be combined. Use `--json` for structured
+one-shot fetches; omit it when following.
+
+### 4. Send a task to a remote agent (exec/attach)
+
+Attach to a running session in driver mode to send input.
+
+```bash
+scripts/agent-exec.sh <session-id> --prompt "Review PR #42 and suggest improvements"
+```
+
+This attaches in driver mode, sends the prompt text, then detaches.
+For interactive sessions, use `kocao sessions attach <id> --driver` directly.
+
+**Important:** `attach` requires an interactive TTY for full bidirectional I/O.
+The `agent-exec.sh` script provides a fire-and-forget prompt delivery mode
+suitable for AI assistant use.
+
+### 5. Start a remote agent
+
+Start a new workspace session. This is typically done through the control-plane
+API or UI. The script wraps the session creation flow.
+
+```bash
+scripts/agent-start.sh --repo https://github.com/org/repo --agent opencode
+```
+
+Supported `--agent` values: `opencode`, `codex`, `claude`, `pi`
+
+The script will:
+1. Call the control-plane API to create a workspace session
+2. Wait for the session to reach `Running` phase
+3. Output the session ID in JSON format
+
+### 6. Stop a remote agent
+
+Stop/terminate a workspace session.
+
+```bash
+scripts/agent-stop.sh <session-id>
+```
+
+This requests graceful termination of the session's harness run.
+
+### 7. Multi-agent workflow
+
+Start multiple agents and distribute tasks:
+
+```bash
+# Start agents
+session1=$(scripts/agent-start.sh --repo https://github.com/org/repo --agent opencode --quiet)
+session2=$(scripts/agent-start.sh --repo https://github.com/org/repo --agent codex --quiet)
+
+# Send tasks
+scripts/agent-exec.sh "$session1" --prompt "Implement the auth module"
+scripts/agent-exec.sh "$session2" --prompt "Write tests for the API endpoints"
+
+# Monitor
+scripts/agent-status.sh "$session1"
+scripts/agent-status.sh "$session2"
+
+# Collect logs
+scripts/agent-logs.sh "$session1" --tail 50
+scripts/agent-logs.sh "$session2" --tail 50
+```
+
+## Symphony Projects
+
+For managed multi-agent orchestration driven by GitHub Projects, use the
+`kocao symphony` commands directly:
+
+```bash
+kocao symphony ls --json          # List symphony projects
+kocao symphony get <name> --json  # Get project details
+kocao symphony create --file <path> --json  # Create from spec
+kocao symphony pause <name>       # Pause processing
+kocao symphony resume <name>      # Resume processing
+kocao symphony refresh <name>     # Force re-sync
+```
+
+## Usage Examples
+
+**User:** "Start a codex agent on the cluster to work on this repo"
+```
+scripts/agent-start.sh --repo https://github.com/withakay/kocao --agent codex
+```
+
+**User:** "What agents are running?"
+```
+scripts/agent-list.sh
+```
+
+**User:** "Check on agent abc-123"
+```
+scripts/agent-status.sh abc-123
+```
+
+**User:** "Show me the logs for that agent"
+```
+scripts/agent-logs.sh abc-123 --tail 100
+```
+
+**User:** "Ask the remote agent to review this PR"
+```
+scripts/agent-exec.sh abc-123 --prompt "Review PR #42"
+```
+
+**User:** "Stop all agents"
+```
+# List all, then stop each
+for id in $(scripts/agent-list.sh | jq -r '.workspaceSessions[] | select(.phase == "Running") | .id'); do
+  scripts/agent-stop.sh "$id"
+done
+```
+
+**User:** "Stream the agent's output"
+```
+scripts/agent-logs.sh abc-123 --follow
+```
+
+## Environment Variables
+
+| Variable | Description | Required |
+|---|---|---|
+| `KOCAO_API_URL` | Control-plane API base URL | Yes (or config file) |
+| `KOCAO_TOKEN` | Bearer token for authentication | Yes (or config file) |
+| `KOCAO_TIMEOUT` | HTTP request timeout (e.g. `30s`) | No (default: 15s) |
+| `KOCAO_VERBOSE` | Enable debug output (`true`/`false`) | No |
+
+## Error Handling
+
+All scripts exit with meaningful codes:
+- `0` — success
+- `1` — API/runtime error (check stderr for details)
+- `2` — usage error (bad arguments, missing binary)
+
+Common errors and fixes are documented in `reference/agents.md`.

--- a/.opencode/skills/kocao-agent/reference/agents.md
+++ b/.opencode/skills/kocao-agent/reference/agents.md
@@ -1,0 +1,176 @@
+# Kocao Agent Reference
+
+## Supported Agents
+
+| Agent | Description | Image |
+|---|---|---|
+| `opencode` | OpenCode AI coding agent (default) | Built from project Dockerfile |
+| `codex` | OpenAI Codex CLI agent | Codex harness image |
+| `claude` | Anthropic Claude Code agent | Claude Code harness image |
+| `pi` | Pi-Agent orchestrator | Pi-Agent harness image |
+
+Each agent type runs in an ephemeral Kubernetes pod ("harness pod") provisioned
+by the Kocao control-plane operator. The pod includes a toolchain-heavy base
+image with common development tools, language runtimes, and SCM tooling.
+
+## Architecture
+
+```
+User/AI Assistant
+    |
+    v
+kocao CLI  --->  Control-Plane API  --->  Kubernetes Operator
+                                              |
+                                              v
+                                        Harness Pod (agent)
+                                          - Git clone
+                                          - Agent process
+                                          - Session artifacts
+```
+
+## Environment Variables
+
+### Required
+
+| Variable | Description | Example |
+|---|---|---|
+| `KOCAO_API_URL` | Control-plane API base URL | `https://kocao.example.com` |
+| `KOCAO_TOKEN` | Bearer token for API authentication | `kocao_tok_...` |
+
+### Optional
+
+| Variable | Description | Default |
+|---|---|---|
+| `KOCAO_TIMEOUT` | HTTP request timeout | `15s` |
+| `KOCAO_VERBOSE` | Enable debug/verbose output | `false` |
+
+### Configuration File
+
+Instead of environment variables, you can use a JSON config file at
+`~/.config/kocao/settings.json`:
+
+```json
+{
+  "api_url": "https://kocao.example.com",
+  "token": "kocao_tok_...",
+  "timeout": "30s",
+  "verbose": false
+}
+```
+
+The CLI also checks for a `settings.json` alongside the binary itself.
+Priority order: env vars > explicit `--config` flag > default config files.
+
+## Prerequisites
+
+1. **kocao CLI installed**
+   ```bash
+   go install github.com/withakay/kocao/cmd/kocao@latest
+   ```
+
+2. **Cluster deployed**
+   The Kocao control-plane and operator must be running in a Kubernetes cluster.
+   See the main project README for deployment instructions.
+
+3. **Agent secrets seeded**
+   Run `seed-agent-secrets` to provision the required Kubernetes secrets for
+   agent authentication (GitHub tokens, API keys, etc.).
+
+4. **Network access**
+   The kocao CLI must be able to reach the control-plane API URL. If running
+   locally, you may need port-forwarding:
+   ```bash
+   kubectl port-forward svc/control-plane-api 8080:8080
+   ```
+
+## CLI Command Reference
+
+### Sessions
+
+```
+kocao sessions ls [--json]
+kocao sessions get <session-id> [--json]
+kocao sessions status <session-id> [--json]
+kocao sessions logs <session-id> [--tail N] [--container NAME] [--follow] [--json]
+kocao sessions attach <session-id> [--driver] [--collab]
+```
+
+### Symphony (Multi-Agent Orchestration)
+
+```
+kocao symphony ls [--json]
+kocao symphony get <project-name> [--json]
+kocao symphony create --file <path> [--json]
+kocao symphony pause <project-name> [--json]
+kocao symphony resume <project-name> [--json]
+kocao symphony refresh <project-name> [--json]
+```
+
+### Global Flags
+
+```
+--config <path>     Config file path (.json)
+--api-url <url>     Control-plane base URL
+--token <token>     Bearer token
+--timeout <dur>     HTTP timeout (e.g. 15s)
+--verbose           Print HTTP request/response diagnostics
+--debug             Alias for --verbose
+```
+
+## Troubleshooting
+
+### "kocao binary not found"
+
+Install the CLI:
+```bash
+go install github.com/withakay/kocao/cmd/kocao@latest
+```
+Or build from source in the project root:
+```bash
+go build -o kocao ./cmd/kocao
+```
+
+### "KOCAO_TOKEN is not set"
+
+Set the token environment variable or create a config file:
+```bash
+export KOCAO_TOKEN="your-token-here"
+```
+
+### "connection refused" or timeout errors
+
+The control-plane API is not reachable. Check:
+1. Is the control-plane running? `kubectl get pods -l app=control-plane-api`
+2. Do you need port-forwarding? `kubectl port-forward svc/control-plane-api 8080:8080`
+3. Is `KOCAO_API_URL` set to the correct URL?
+
+### "no active run pod for workspace session"
+
+The session exists but has no running harness pod. This can mean:
+- The session is still starting (check `kocao sessions status <id>`)
+- The session's run failed (check phase in status output)
+- The pod was evicted (check Kubernetes events)
+
+### "API returned HTTP 401"
+
+Your token is invalid or expired. Regenerate it and update `KOCAO_TOKEN`.
+
+### "API returned HTTP 404"
+
+The session ID does not exist, or the API endpoint is not available.
+Double-check the session ID with `kocao sessions ls`.
+
+### "attach requires an interactive terminal (TTY)"
+
+The `attach` command needs a real terminal. It cannot run inside a non-TTY
+context (like a pipe or background process). Use `agent-exec.sh` for
+non-interactive prompt delivery, or run attach from a real terminal.
+
+### Session stuck in "Pending"
+
+The harness pod may be waiting for resources. Check:
+```bash
+kubectl get pods -l workspace-session-id=<session-id>
+kubectl describe pod <pod-name>
+```
+Look for scheduling issues, resource limits, or image pull errors.

--- a/.opencode/skills/kocao-agent/reference/agents.md
+++ b/.opencode/skills/kocao-agent/reference/agents.md
@@ -1,36 +1,51 @@
 # Kocao Agent Reference
 
-## Supported Agents
+## What This Skill Manages
 
-| Agent | Description | Image |
-|---|---|---|
-| `opencode` | OpenCode AI coding agent (default) | Built from project Dockerfile |
-| `codex` | OpenAI Codex CLI agent | Codex harness image |
-| `claude` | Anthropic Claude Code agent | Claude Code harness image |
-| `pi` | Pi-Agent orchestrator | Pi-Agent harness image |
+The `kocao-agent` skill manages **workspace sessions** in the Kocao control
+plane. A workspace session is the lifecycle wrapper around a harness pod.
 
-Each agent type runs in an ephemeral Kubernetes pod ("harness pod") provisioned
-by the Kocao control-plane operator. The pod includes a toolchain-heavy base
-image with common development tools, language runtimes, and SCM tooling.
+Important limitation: the current session-creation API is generic. It does not
+choose between different runtime images or agent implementations. The
+`agent-start.sh --agent ...` flag is a **labeling convention** that keeps
+session names readable for humans.
+
+## Common Session Labels
+
+| Label | Typical intended workflow |
+|---|---|
+| `opencode` | OpenCode-led coding or review work |
+| `codex` | Codex CLI work inside the session |
+| `claude` | Claude Code work inside the session |
+| `pi` | Pi-Agent orchestration work inside the session |
+
+Use the label to communicate intent. Whether a given CLI is actually usable in
+the pod still depends on the deployed harness image and injected credentials.
 
 ## Architecture
 
 ```
-User/AI Assistant
+User / AI assistant
     |
     v
-kocao CLI  --->  Control-Plane API  --->  Kubernetes Operator
-                                              |
-                                              v
-                                        Harness Pod (agent)
-                                          - Git clone
-                                          - Agent process
-                                          - Session artifacts
+Skill scripts / kocao CLI
+    |
+    v
+Control-plane API
+    |
+    v
+Workspace session
+    |
+    v
+Harness pod
+  - Git clone / working copy
+  - Agent CLI processes
+  - Session artifacts and logs
 ```
 
 ## Environment Variables
 
-### Required
+### Required for API-backed scripts
 
 | Variable | Description | Example |
 |---|---|---|
@@ -41,12 +56,12 @@ kocao CLI  --->  Control-Plane API  --->  Kubernetes Operator
 
 | Variable | Description | Default |
 |---|---|---|
-| `KOCAO_TIMEOUT` | HTTP request timeout | `15s` |
-| `KOCAO_VERBOSE` | Enable debug/verbose output | `false` |
+| `KOCAO_TIMEOUT` | CLI HTTP timeout | `15s` |
+| `KOCAO_VERBOSE` | Enable CLI debug output | `false` |
 
 ### Configuration File
 
-Instead of environment variables, you can use a JSON config file at
+Instead of environment variables, the CLI can read a JSON config file from
 `~/.config/kocao/settings.json`:
 
 ```json
@@ -58,7 +73,6 @@ Instead of environment variables, you can use a JSON config file at
 }
 ```
 
-The CLI also checks for a `settings.json` alongside the binary itself.
 Priority order: env vars > explicit `--config` flag > default config files.
 
 ## Prerequisites
@@ -69,108 +83,100 @@ Priority order: env vars > explicit `--config` flag > default config files.
    ```
 
 2. **Cluster deployed**
-   The Kocao control-plane and operator must be running in a Kubernetes cluster.
-   See the main project README for deployment instructions.
+   The Kocao control-plane and operator must be reachable.
 
 3. **Agent secrets seeded**
-   Run `seed-agent-secrets` to provision the required Kubernetes secrets for
-   agent authentication (GitHub tokens, API keys, etc.).
+   Run `seed-agent-secrets` so the harness pods get the credentials they need.
 
 4. **Network access**
-   The kocao CLI must be able to reach the control-plane API URL. If running
-   locally, you may need port-forwarding:
+   If you are running locally, you may need port-forwarding:
    ```bash
    kubectl port-forward svc/control-plane-api 8080:8080
    ```
 
-## CLI Command Reference
+## Commands Used by This Skill
 
-### Sessions
+### CLI-backed wrappers
 
-```
+```bash
 kocao sessions ls [--json]
-kocao sessions get <session-id> [--json]
 kocao sessions status <session-id> [--json]
 kocao sessions logs <session-id> [--tail N] [--container NAME] [--follow] [--json]
 kocao sessions attach <session-id> [--driver] [--collab]
 ```
 
-### Symphony (Multi-Agent Orchestration)
+### API-backed wrappers
 
-```
-kocao symphony ls [--json]
-kocao symphony get <project-name> [--json]
-kocao symphony create --file <path> [--json]
-kocao symphony pause <project-name> [--json]
-kocao symphony resume <project-name> [--json]
-kocao symphony refresh <project-name> [--json]
+```text
+POST   /api/v1/workspace-sessions
+DELETE /api/v1/workspace-sessions/<session-id>
+POST   /api/v1/workspace-sessions/<session-id>/exec   # optional / experimental
 ```
 
-### Global Flags
+## Behavior Notes
 
-```
---config <path>     Config file path (.json)
---api-url <url>     Control-plane base URL
---token <token>     Bearer token
---timeout <dur>     HTTP timeout (e.g. 15s)
---verbose           Print HTTP request/response diagnostics
---debug             Alias for --verbose
-```
+### `agent-start.sh`
+
+- requires `--repo`
+- accepts `--agent`, but only to help generate a readable display name
+- waits for `Running` by default
+- `--quiet` prints only the session ID
+
+### `agent-exec.sh`
+
+- depends on a control-plane that implements `/exec`
+- if that endpoint is missing, the script exits with guidance to use
+  `kocao sessions attach <id> --driver`
+
+### `agent-logs.sh`
+
+- defaults to JSON for one-shot fetches
+- requires `--no-json` when you use `--follow`
 
 ## Troubleshooting
 
-### "kocao binary not found"
+### `required command not found: kocao`
 
 Install the CLI:
 ```bash
 go install github.com/withakay/kocao/cmd/kocao@latest
 ```
-Or build from source in the project root:
-```bash
-go build -o kocao ./cmd/kocao
-```
 
-### "KOCAO_TOKEN is not set"
+### `KOCAO_TOKEN is not set`
 
-Set the token environment variable or create a config file:
+Export the token or create the config file:
 ```bash
 export KOCAO_TOKEN="your-token-here"
 ```
 
-### "connection refused" or timeout errors
+### `API returned HTTP 400`
 
-The control-plane API is not reachable. Check:
-1. Is the control-plane running? `kubectl get pods -l app=control-plane-api`
-2. Do you need port-forwarding? `kubectl port-forward svc/control-plane-api 8080:8080`
-3. Is `KOCAO_API_URL` set to the correct URL?
+The most common causes are:
+- invalid JSON sent to the API
+- `repoURL` missing on session creation
+- `repoURL` not using `https://`
 
-### "no active run pod for workspace session"
+### `API returned HTTP 401`
 
-The session exists but has no running harness pod. This can mean:
-- The session is still starting (check `kocao sessions status <id>`)
-- The session's run failed (check phase in status output)
-- The pod was evicted (check Kubernetes events)
+The bearer token is missing, invalid, or expired.
 
-### "API returned HTTP 401"
+### `API returned HTTP 404`
 
-Your token is invalid or expired. Regenerate it and update `KOCAO_TOKEN`.
+Usually one of these:
+- the session ID is wrong
+- the session has already been deleted
+- you tried `agent-exec.sh` against a control-plane that does not implement the optional `/exec` endpoint
 
-### "API returned HTTP 404"
+### `attach requires an interactive terminal (TTY)`
 
-The session ID does not exist, or the API endpoint is not available.
-Double-check the session ID with `kocao sessions ls`.
+`kocao sessions attach` needs a real terminal. Use it from an interactive shell.
 
-### "attach requires an interactive terminal (TTY)"
+### Session stuck in `Pending`
 
-The `attach` command needs a real terminal. It cannot run inside a non-TTY
-context (like a pipe or background process). Use `agent-exec.sh` for
-non-interactive prompt delivery, or run attach from a real terminal.
-
-### Session stuck in "Pending"
-
-The harness pod may be waiting for resources. Check:
+Check whether Kubernetes can schedule the harness pod:
 ```bash
 kubectl get pods -l workspace-session-id=<session-id>
 kubectl describe pod <pod-name>
 ```
-Look for scheduling issues, resource limits, or image pull errors.
+
+Look for scheduling failures, image pull errors, or missing secrets.

--- a/.opencode/skills/kocao-agent/scripts/agent-exec.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-exec.sh
@@ -1,129 +1,82 @@
 #!/usr/bin/env bash
 # agent-exec.sh — Send a prompt/command to a running workspace session.
-# Uses the attach mechanism to deliver input in driver mode.
-# For full interactive sessions, use `kocao sessions attach <id> --driver` directly.
+# Uses the experimental /exec API when it is available on the control-plane.
 # Exit codes: 0=success, 1=runtime error, 2=usage error
 set -euo pipefail
 
-# --- Preflight ---
-if ! command -v kocao &>/dev/null; then
-  echo "error: kocao binary not found in PATH" >&2
-  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
-  exit 2
-fi
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.opencode/skills/kocao-agent/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
 
-if ! command -v curl &>/dev/null; then
-  echo "error: curl is required but not found in PATH" >&2
-  exit 2
-fi
+usage() {
+  cat <<'EOF'
+Usage: agent-exec.sh <session-id> --prompt <text>
 
-if ! command -v jq &>/dev/null; then
-  echo "error: jq is required but not found in PATH" >&2
-  exit 2
-fi
+Send a prompt to a running workspace session through the control-plane exec API.
 
-# --- Defaults ---
-SESSION_ID=""
-PROMPT=""
-API_URL="${KOCAO_API_URL:-http://127.0.0.1:8080}"
-TOKEN="${KOCAO_TOKEN:-}"
+Arguments:
+  session-id       Workspace session ID
 
-# --- Parse args ---
-while [[ $# -gt 0 ]]; do
+Options:
+  --prompt, -p     Prompt text to send (required)
+  --help           Show this help
+
+Notes:
+  This script depends on the optional `/api/v1/workspace-sessions/<id>/exec`
+  endpoint. If your control-plane does not expose that endpoint yet, use:
+    kocao sessions attach <session-id> --driver
+EOF
+}
+
+require_commands curl jq
+
+session_id=""
+prompt=""
+api_response_file=""
+trap '[[ -n "$api_response_file" ]] && rm -f "$api_response_file"' EXIT
+
+while (($#)); do
   case "$1" in
     --prompt|-p)
-      PROMPT="$2"
+      require_flag_value "$1" "$#"
+      prompt="$2"
       shift 2
       ;;
     --help|-h)
-      echo "Usage: agent-exec.sh <session-id> --prompt <text>"
-      echo ""
-      echo "Send a prompt to a running workspace session."
-      echo ""
-      echo "Arguments:"
-      echo "  session-id       Workspace session ID"
-      echo ""
-      echo "Options:"
-      echo "  --prompt TEXT    The prompt/command to send (required)"
-      echo "  --help           Show this help"
-      echo ""
-      echo "Note: This sends the prompt via the control-plane exec API."
-      echo "For interactive terminal sessions, use:"
-      echo "  kocao sessions attach <session-id> --driver"
+      usage
       exit 0
       ;;
     -*)
-      echo "error: unknown flag: $1" >&2
-      exit 2
+      usage_error "unknown flag: $1"
       ;;
     *)
-      if [[ -z "$SESSION_ID" ]]; then
-        SESSION_ID="$1"
-      else
-        echo "error: unexpected argument: $1" >&2
-        exit 2
+      if [[ -n "$session_id" ]]; then
+        usage_error "unexpected argument: $1"
       fi
+      session_id="$1"
       shift
       ;;
   esac
 done
 
-if [[ -z "$SESSION_ID" ]]; then
-  echo "error: session-id is required" >&2
-  echo "Usage: agent-exec.sh <session-id> --prompt <text>" >&2
-  exit 2
-fi
+require_nonempty "$session_id" "session-id"
+require_nonempty "$prompt" "--prompt"
 
-if [[ -z "$PROMPT" ]]; then
-  echo "error: --prompt is required" >&2
-  exit 2
-fi
-
-if [[ -z "$TOKEN" ]]; then
-  echo "error: KOCAO_TOKEN is not set" >&2
-  exit 2
-fi
-
-# --- Send prompt via exec API ---
-# The exec endpoint sends a prompt to the running agent session.
-# If the API does not have a dedicated exec endpoint, fall back to
-# delivering input via the attach-token + websocket mechanism.
-API_URL="${API_URL%/}"
-ENCODED_ID=$(printf '%s' "$SESSION_ID" | jq -sRr @uri)
-
-PAYLOAD=$(jq -n --arg prompt "$PROMPT" '{"prompt": $prompt}')
-
-RESPONSE=$(curl -s -w "\n%{http_code}" \
-  -X POST \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -d "$PAYLOAD" \
-  "${API_URL}/api/v1/workspace-sessions/${ENCODED_ID}/exec" \
-  2>&1) || {
-  echo "error: failed to call control-plane API" >&2
-  exit 1
-}
-
-HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-BODY=$(echo "$RESPONSE" | sed '$d')
-
-if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
-  # If exec endpoint is not available (404), report with guidance
-  if [[ "$HTTP_CODE" == "404" ]]; then
-    echo "error: exec endpoint not available (HTTP 404)" >&2
-    echo "The control-plane may not support the exec API yet." >&2
-    echo "Use interactive attach instead: kocao sessions attach ${SESSION_ID} --driver" >&2
+payload="$(jq -n --arg prompt "$prompt" '{prompt: $prompt}')"
+api_request POST "/api/v1/workspace-sessions/$(urlencode "$session_id")/exec" "$payload"
+api_response_file="$API_RESPONSE_FILE"
+if ! api_request_ok; then
+  if [[ "$API_RESPONSE_CODE" == '404' ]]; then
+    echo 'error: exec endpoint is not available on this control-plane' >&2
+    echo "Use interactive attach instead: kocao sessions attach ${session_id} --driver" >&2
     exit 1
   fi
-  echo "error: API returned HTTP ${HTTP_CODE}" >&2
-  echo "$BODY" >&2
+  print_api_error "$API_RESPONSE_CODE" "$API_RESPONSE_FILE"
   exit 1
 fi
 
-# --- Output ---
-if [[ -n "$BODY" ]]; then
-  echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+if [[ -s "$API_RESPONSE_FILE" ]]; then
+  print_json_or_raw "$API_RESPONSE_FILE"
 else
-  jq -n --arg sid "$SESSION_ID" '{status:"sent",sessionId:$sid}'
+  jq -n --arg sid "$session_id" '{status:"sent",sessionId:$sid}'
 fi

--- a/.opencode/skills/kocao-agent/scripts/agent-exec.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-exec.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# agent-exec.sh — Send a prompt/command to a running workspace session.
+# Uses the attach mechanism to deliver input in driver mode.
+# For full interactive sessions, use `kocao sessions attach <id> --driver` directly.
+# Exit codes: 0=success, 1=runtime error, 2=usage error
+set -euo pipefail
+
+# --- Preflight ---
+if ! command -v kocao &>/dev/null; then
+  echo "error: kocao binary not found in PATH" >&2
+  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
+  exit 2
+fi
+
+if ! command -v curl &>/dev/null; then
+  echo "error: curl is required but not found in PATH" >&2
+  exit 2
+fi
+
+# --- Defaults ---
+SESSION_ID=""
+PROMPT=""
+API_URL="${KOCAO_API_URL:-http://127.0.0.1:8080}"
+TOKEN="${KOCAO_TOKEN:-}"
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prompt|-p)
+      PROMPT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Usage: agent-exec.sh <session-id> --prompt <text>"
+      echo ""
+      echo "Send a prompt to a running workspace session."
+      echo ""
+      echo "Arguments:"
+      echo "  session-id       Workspace session ID"
+      echo ""
+      echo "Options:"
+      echo "  --prompt TEXT    The prompt/command to send (required)"
+      echo "  --help           Show this help"
+      echo ""
+      echo "Note: This sends the prompt via the control-plane exec API."
+      echo "For interactive terminal sessions, use:"
+      echo "  kocao sessions attach <session-id> --driver"
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$SESSION_ID" ]]; then
+        SESSION_ID="$1"
+      else
+        echo "error: unexpected argument: $1" >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$SESSION_ID" ]]; then
+  echo "error: session-id is required" >&2
+  echo "Usage: agent-exec.sh <session-id> --prompt <text>" >&2
+  exit 2
+fi
+
+if [[ -z "$PROMPT" ]]; then
+  echo "error: --prompt is required" >&2
+  exit 2
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  echo "error: KOCAO_TOKEN is not set" >&2
+  exit 2
+fi
+
+# --- Send prompt via exec API ---
+# The exec endpoint sends a prompt to the running agent session.
+# If the API does not have a dedicated exec endpoint, fall back to
+# delivering input via the attach-token + websocket mechanism.
+API_URL="${API_URL%/}"
+ENCODED_ID=$(printf '%s' "$SESSION_ID" | jq -sRr @uri)
+
+PAYLOAD=$(jq -n --arg prompt "$PROMPT" '{"prompt": $prompt}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d "$PAYLOAD" \
+  "${API_URL}/api/v1/workspace-sessions/${ENCODED_ID}/exec" \
+  2>&1) || {
+  echo "error: failed to call control-plane API" >&2
+  exit 1
+}
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  # If exec endpoint is not available (404), report with guidance
+  if [[ "$HTTP_CODE" == "404" ]]; then
+    echo "error: exec endpoint not available (HTTP 404)" >&2
+    echo "The control-plane may not support the exec API yet." >&2
+    echo "Use interactive attach instead: kocao sessions attach ${SESSION_ID} --driver" >&2
+    exit 1
+  fi
+  echo "error: API returned HTTP ${HTTP_CODE}" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+# --- Output ---
+if [[ -n "$BODY" ]]; then
+  echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+else
+  echo "{\"status\":\"sent\",\"sessionId\":\"${SESSION_ID}\"}"
+fi

--- a/.opencode/skills/kocao-agent/scripts/agent-exec.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-exec.sh
@@ -17,6 +17,11 @@ if ! command -v curl &>/dev/null; then
   exit 2
 fi
 
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 2
+fi
+
 # --- Defaults ---
 SESSION_ID=""
 PROMPT=""
@@ -120,5 +125,5 @@ fi
 if [[ -n "$BODY" ]]; then
   echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
 else
-  echo "{\"status\":\"sent\",\"sessionId\":\"${SESSION_ID}\"}"
+  jq -n --arg sid "$SESSION_ID" '{status:"sent",sessionId:$sid}'
 fi

--- a/.opencode/skills/kocao-agent/scripts/agent-list.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-list.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# agent-list.sh — List all workspace sessions via kocao CLI.
+# Wraps: kocao sessions ls --json
+# Exit codes: 0=success, 1=runtime error, 2=usage error
+set -euo pipefail
+
+# --- Preflight ---
+if ! command -v kocao &>/dev/null; then
+  echo "error: kocao binary not found in PATH" >&2
+  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
+  exit 2
+fi
+
+# --- Parse args ---
+OUTPUT_FORMAT="--json"
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-json)
+      OUTPUT_FORMAT=""
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: agent-list.sh [--no-json]"
+      echo ""
+      echo "List all workspace sessions."
+      echo ""
+      echo "Options:"
+      echo "  --no-json   Output human-readable table instead of JSON"
+      echo "  --help      Show this help"
+      exit 0
+      ;;
+    *)
+      EXTRA_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# --- Execute ---
+exec kocao sessions ls ${OUTPUT_FORMAT} "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"

--- a/.opencode/skills/kocao-agent/scripts/agent-list.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-list.sh
@@ -4,39 +4,49 @@
 # Exit codes: 0=success, 1=runtime error, 2=usage error
 set -euo pipefail
 
-# --- Preflight ---
-if ! command -v kocao &>/dev/null; then
-  echo "error: kocao binary not found in PATH" >&2
-  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
-  exit 2
-fi
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.opencode/skills/kocao-agent/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
 
-# --- Parse args ---
-OUTPUT_FORMAT="--json"
-EXTRA_ARGS=()
+usage() {
+  cat <<'EOF'
+Usage: agent-list.sh [--no-json] [extra kocao flags]
 
-while [[ $# -gt 0 ]]; do
+List all workspace sessions.
+
+Options:
+  --no-json   Output the default kocao table instead of JSON
+  --help      Show this help
+
+Any additional arguments are passed through to `kocao sessions ls`.
+EOF
+}
+
+require_commands kocao
+
+json_out=true
+extra_args=()
+while (($#)); do
   case "$1" in
     --no-json)
-      OUTPUT_FORMAT=""
+      json_out=false
       shift
       ;;
     --help|-h)
-      echo "Usage: agent-list.sh [--no-json]"
-      echo ""
-      echo "List all workspace sessions."
-      echo ""
-      echo "Options:"
-      echo "  --no-json   Output human-readable table instead of JSON"
-      echo "  --help      Show this help"
+      usage
       exit 0
       ;;
     *)
-      EXTRA_ARGS+=("$1")
+      extra_args+=("$1")
       shift
       ;;
   esac
 done
 
-# --- Execute ---
-exec kocao sessions ls ${OUTPUT_FORMAT} "${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}"
+cmd=(kocao sessions ls)
+if [[ "$json_out" == true ]]; then
+  cmd+=(--json)
+fi
+cmd+=("${extra_args[@]}")
+
+exec "${cmd[@]}"

--- a/.opencode/skills/kocao-agent/scripts/agent-logs.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-logs.sh
@@ -37,6 +37,7 @@ tail_lines=""
 container_name=""
 follow=false
 json_out=true
+explicit_json=false
 while (($#)); do
   case "$1" in
     --tail)
@@ -52,10 +53,14 @@ while (($#)); do
       ;;
     --follow|-f)
       follow=true
+      if [[ "$explicit_json" == false ]]; then
+        json_out=false
+      fi
       shift
       ;;
     --json)
       json_out=true
+      explicit_json=true
       shift
       ;;
     --no-json)
@@ -80,7 +85,7 @@ while (($#)); do
 done
 
 require_nonempty "$session_id" "session-id"
-if [[ "$follow" == true && "$json_out" == true ]]; then
+if [[ "$follow" == true && "$explicit_json" == true ]]; then
   usage_error "--follow cannot be combined with --json"
 fi
 

--- a/.opencode/skills/kocao-agent/scripts/agent-logs.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-logs.sh
@@ -4,99 +4,97 @@
 # Exit codes: 0=success, 1=runtime error, 2=usage error
 set -euo pipefail
 
-# --- Preflight ---
-if ! command -v kocao &>/dev/null; then
-  echo "error: kocao binary not found in PATH" >&2
-  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
-  exit 2
-fi
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.opencode/skills/kocao-agent/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
 
-# --- Defaults ---
-SESSION_ID=""
-TAIL=""
-CONTAINER=""
-FOLLOW=false
-JSON_OUT=true
+usage() {
+  cat <<'EOF'
+Usage: agent-logs.sh <session-id> [--tail N] [--container NAME] [--follow] [--json|--no-json]
 
-# --- Parse args ---
-while [[ $# -gt 0 ]]; do
+Fetch or stream logs from a workspace session.
+
+Arguments:
+  session-id       Workspace session ID
+
+Options:
+  --tail N         Number of log lines to fetch
+  --container NAME Container name within the pod
+  --follow, -f     Stream logs continuously
+  --json           Output JSON (default for one-shot fetches)
+  --no-json        Output plain text
+  --help           Show this help
+
+Notes:
+  --follow and --json cannot be combined.
+EOF
+}
+
+require_commands kocao
+
+session_id=""
+tail_lines=""
+container_name=""
+follow=false
+json_out=true
+while (($#)); do
   case "$1" in
     --tail)
-      TAIL="$2"
+      require_flag_value "$1" "$#"
+      tail_lines="$2"
+      require_positive_integer "$tail_lines" "--tail"
       shift 2
       ;;
     --container)
-      CONTAINER="$2"
+      require_flag_value "$1" "$#"
+      container_name="$2"
       shift 2
       ;;
     --follow|-f)
-      FOLLOW=true
-      JSON_OUT=false  # --follow and --json are incompatible
+      follow=true
       shift
       ;;
     --json)
-      JSON_OUT=true
+      json_out=true
       shift
       ;;
     --no-json)
-      JSON_OUT=false
+      json_out=false
       shift
       ;;
     --help|-h)
-      echo "Usage: agent-logs.sh <session-id> [--tail N] [--container NAME] [--follow] [--json|--no-json]"
-      echo ""
-      echo "Fetch or stream logs from a workspace session."
-      echo ""
-      echo "Arguments:"
-      echo "  session-id       Workspace session ID"
-      echo ""
-      echo "Options:"
-      echo "  --tail N         Number of log lines (default: 200)"
-      echo "  --container NAME Container name within the pod"
-      echo "  --follow, -f     Continuously poll for new logs"
-      echo "  --json           Output structured JSON (default; incompatible with --follow)"
-      echo "  --no-json        Output plain text"
-      echo "  --help           Show this help"
+      usage
       exit 0
       ;;
     -*)
-      echo "error: unknown flag: $1" >&2
-      exit 2
+      usage_error "unknown flag: $1"
       ;;
     *)
-      if [[ -z "$SESSION_ID" ]]; then
-        SESSION_ID="$1"
-      else
-        echo "error: unexpected argument: $1" >&2
-        exit 2
+      if [[ -n "$session_id" ]]; then
+        usage_error "unexpected argument: $1"
       fi
+      session_id="$1"
       shift
       ;;
   esac
 done
 
-if [[ -z "$SESSION_ID" ]]; then
-  echo "error: session-id is required" >&2
-  echo "Usage: agent-logs.sh <session-id> [--tail N] [--follow]" >&2
-  exit 2
+require_nonempty "$session_id" "session-id"
+if [[ "$follow" == true && "$json_out" == true ]]; then
+  usage_error "--follow cannot be combined with --json"
 fi
 
-# --- Build command ---
-CMD=(kocao sessions logs "$SESSION_ID")
-
-if [[ -n "$TAIL" ]]; then
-  CMD+=(--tail "$TAIL")
+cmd=(kocao sessions logs "$session_id")
+if [[ -n "$tail_lines" ]]; then
+  cmd+=(--tail "$tail_lines")
+fi
+if [[ -n "$container_name" ]]; then
+  cmd+=(--container "$container_name")
+fi
+if [[ "$follow" == true ]]; then
+  cmd+=(--follow)
+elif [[ "$json_out" == true ]]; then
+  cmd+=(--json)
 fi
 
-if [[ -n "$CONTAINER" ]]; then
-  CMD+=(--container "$CONTAINER")
-fi
-
-if [[ "$FOLLOW" == true ]]; then
-  CMD+=(--follow)
-elif [[ "$JSON_OUT" == true ]]; then
-  CMD+=(--json)
-fi
-
-# --- Execute ---
-exec "${CMD[@]}"
+exec "${cmd[@]}"

--- a/.opencode/skills/kocao-agent/scripts/agent-logs.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-logs.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# agent-logs.sh — Stream or fetch logs from a workspace session's pod.
+# Wraps: kocao sessions logs <id> [--tail N] [--container NAME] [--follow] [--json]
+# Exit codes: 0=success, 1=runtime error, 2=usage error
+set -euo pipefail
+
+# --- Preflight ---
+if ! command -v kocao &>/dev/null; then
+  echo "error: kocao binary not found in PATH" >&2
+  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
+  exit 2
+fi
+
+# --- Defaults ---
+SESSION_ID=""
+TAIL=""
+CONTAINER=""
+FOLLOW=false
+JSON_OUT=true
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tail)
+      TAIL="$2"
+      shift 2
+      ;;
+    --container)
+      CONTAINER="$2"
+      shift 2
+      ;;
+    --follow|-f)
+      FOLLOW=true
+      JSON_OUT=false  # --follow and --json are incompatible
+      shift
+      ;;
+    --json)
+      JSON_OUT=true
+      shift
+      ;;
+    --no-json)
+      JSON_OUT=false
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: agent-logs.sh <session-id> [--tail N] [--container NAME] [--follow] [--json|--no-json]"
+      echo ""
+      echo "Fetch or stream logs from a workspace session."
+      echo ""
+      echo "Arguments:"
+      echo "  session-id       Workspace session ID"
+      echo ""
+      echo "Options:"
+      echo "  --tail N         Number of log lines (default: 200)"
+      echo "  --container NAME Container name within the pod"
+      echo "  --follow, -f     Continuously poll for new logs"
+      echo "  --json           Output structured JSON (default; incompatible with --follow)"
+      echo "  --no-json        Output plain text"
+      echo "  --help           Show this help"
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$SESSION_ID" ]]; then
+        SESSION_ID="$1"
+      else
+        echo "error: unexpected argument: $1" >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$SESSION_ID" ]]; then
+  echo "error: session-id is required" >&2
+  echo "Usage: agent-logs.sh <session-id> [--tail N] [--follow]" >&2
+  exit 2
+fi
+
+# --- Build command ---
+CMD=(kocao sessions logs "$SESSION_ID")
+
+if [[ -n "$TAIL" ]]; then
+  CMD+=(--tail "$TAIL")
+fi
+
+if [[ -n "$CONTAINER" ]]; then
+  CMD+=(--container "$CONTAINER")
+fi
+
+if [[ "$FOLLOW" == true ]]; then
+  CMD+=(--follow)
+elif [[ "$JSON_OUT" == true ]]; then
+  CMD+=(--json)
+fi
+
+# --- Execute ---
+exec "${CMD[@]}"

--- a/.opencode/skills/kocao-agent/scripts/agent-start.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-start.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# agent-start.sh — Create a new workspace session via the kocao control-plane API.
+# This script calls the API directly since the CLI does not yet have a
+# "sessions create" subcommand.
+# Exit codes: 0=success, 1=runtime error, 2=usage error
+set -euo pipefail
+
+# --- Preflight ---
+if ! command -v kocao &>/dev/null; then
+  echo "error: kocao binary not found in PATH" >&2
+  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
+  exit 2
+fi
+
+if ! command -v curl &>/dev/null; then
+  echo "error: curl is required but not found in PATH" >&2
+  exit 2
+fi
+
+# --- Defaults ---
+REPO_URL=""
+AGENT="opencode"
+DISPLAY_NAME=""
+QUIET=false
+API_URL="${KOCAO_API_URL:-http://127.0.0.1:8080}"
+TOKEN="${KOCAO_TOKEN:-}"
+WAIT=true
+WAIT_TIMEOUT=120
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO_URL="$2"
+      shift 2
+      ;;
+    --agent)
+      AGENT="$2"
+      shift 2
+      ;;
+    --name)
+      DISPLAY_NAME="$2"
+      shift 2
+      ;;
+    --quiet|-q)
+      QUIET=true
+      shift
+      ;;
+    --no-wait)
+      WAIT=false
+      shift
+      ;;
+    --wait-timeout)
+      WAIT_TIMEOUT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Usage: agent-start.sh --repo <url> [--agent <name>] [--name <display-name>] [--quiet] [--no-wait]"
+      echo ""
+      echo "Create a new workspace session."
+      echo ""
+      echo "Options:"
+      echo "  --repo URL          Repository URL (required)"
+      echo "  --agent NAME        Agent type: opencode, codex, claude, pi (default: opencode)"
+      echo "  --name NAME         Display name for the session"
+      echo "  --quiet             Output only the session ID"
+      echo "  --no-wait           Don't wait for Running phase"
+      echo "  --wait-timeout SEC  Max seconds to wait for Running (default: 120)"
+      echo "  --help              Show this help"
+      exit 0
+      ;;
+    *)
+      echo "error: unknown flag: $1" >&2
+      echo "Run with --help for usage" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$REPO_URL" ]]; then
+  echo "error: --repo is required" >&2
+  exit 2
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  echo "error: KOCAO_TOKEN is not set" >&2
+  exit 2
+fi
+
+# Validate agent type
+case "$AGENT" in
+  opencode|codex|claude|pi) ;;
+  *)
+    echo "error: unsupported agent type: $AGENT (expected: opencode, codex, claude, pi)" >&2
+    exit 2
+    ;;
+esac
+
+# --- Build request ---
+if [[ -z "$DISPLAY_NAME" ]]; then
+  DISPLAY_NAME="${AGENT}-$(date +%s)"
+fi
+
+PAYLOAD=$(cat <<EOF
+{
+  "displayName": "${DISPLAY_NAME}",
+  "repoURL": "${REPO_URL}",
+  "agent": "${AGENT}"
+}
+EOF
+)
+
+# --- Create session ---
+API_URL="${API_URL%/}"
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d "$PAYLOAD" \
+  "${API_URL}/api/v1/workspace-sessions" \
+  2>&1) || {
+  echo "error: failed to call control-plane API" >&2
+  exit 1
+}
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  echo "error: API returned HTTP ${HTTP_CODE}" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+SESSION_ID=$(echo "$BODY" | jq -r '.id // empty' 2>/dev/null)
+if [[ -z "$SESSION_ID" ]]; then
+  echo "error: could not extract session ID from response" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+# --- Wait for Running (optional) ---
+if [[ "$WAIT" == true ]]; then
+  ELAPSED=0
+  while [[ $ELAPSED -lt $WAIT_TIMEOUT ]]; do
+    STATUS_JSON=$(kocao sessions status "$SESSION_ID" --json 2>/dev/null) || true
+    PHASE=$(echo "$STATUS_JSON" | jq -r '.session.phase // empty' 2>/dev/null)
+    case "$PHASE" in
+      Running)
+        break
+        ;;
+      Failed)
+        echo "error: session entered Failed phase" >&2
+        echo "$STATUS_JSON" | jq . >&2 2>/dev/null || echo "$STATUS_JSON" >&2
+        exit 1
+        ;;
+    esac
+    sleep 3
+    ELAPSED=$((ELAPSED + 3))
+  done
+
+  if [[ $ELAPSED -ge $WAIT_TIMEOUT ]]; then
+    echo "warning: timed out waiting for Running phase (current: ${PHASE:-unknown})" >&2
+  fi
+fi
+
+# --- Output ---
+if [[ "$QUIET" == true ]]; then
+  echo "$SESSION_ID"
+else
+  echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+fi

--- a/.opencode/skills/kocao-agent/scripts/agent-start.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-start.sh
@@ -30,7 +30,7 @@ Notes:
 EOF
 }
 
-require_commands kocao curl jq
+require_commands curl jq
 
 repo_url=""
 agent_label="opencode"
@@ -84,6 +84,10 @@ while (($#)); do
       ;;
   esac
 done
+
+if [[ "$wait_for_running" == true ]]; then
+  require_command kocao
+fi
 
 require_nonempty "$repo_url" "--repo"
 case "$agent_label" in

--- a/.opencode/skills/kocao-agent/scripts/agent-start.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-start.sh
@@ -39,7 +39,12 @@ quiet=false
 wait_for_running=true
 wait_timeout=120
 api_response_file=""
-trap '[[ -n "$api_response_file" ]] && rm -f "$api_response_file"' EXIT
+_start_temp_files=()
+_start_cleanup() {
+  rm -f "${_start_temp_files[@]}" 2>/dev/null || true
+  [[ -n "$api_response_file" ]] && rm -f "$api_response_file"
+}
+trap '_start_cleanup' EXIT
 
 while (($#)); do
   case "$1" in
@@ -128,6 +133,8 @@ if [[ "$wait_for_running" == true ]]; then
         status_file="$(mktemp)"
         printf '%s' "$status_json" > "$status_file"
         final_output="$status_file"
+        # Track original file for cleanup before reassigning
+        _start_temp_files+=("$api_response_file")
         api_response_file="$status_file"
         break
         ;;

--- a/.opencode/skills/kocao-agent/scripts/agent-start.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-start.sh
@@ -17,6 +17,11 @@ if ! command -v curl &>/dev/null; then
   exit 2
 fi
 
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 2
+fi
+
 # --- Defaults ---
 REPO_URL=""
 AGENT="opencode"
@@ -101,14 +106,11 @@ if [[ -z "$DISPLAY_NAME" ]]; then
   DISPLAY_NAME="${AGENT}-$(date +%s)"
 fi
 
-PAYLOAD=$(cat <<EOF
-{
-  "displayName": "${DISPLAY_NAME}",
-  "repoURL": "${REPO_URL}",
-  "agent": "${AGENT}"
-}
-EOF
-)
+PAYLOAD=$(jq -n \
+  --arg displayName "$DISPLAY_NAME" \
+  --arg repoURL "$REPO_URL" \
+  --arg agent "$AGENT" \
+  '{displayName: $displayName, repoURL: $repoURL, agent: $agent}')
 
 # --- Create session ---
 API_URL="${API_URL%/}"

--- a/.opencode/skills/kocao-agent/scripts/agent-start.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-start.sh
@@ -1,175 +1,151 @@
 #!/usr/bin/env bash
 # agent-start.sh — Create a new workspace session via the kocao control-plane API.
-# This script calls the API directly since the CLI does not yet have a
-# "sessions create" subcommand.
+# The API currently creates a generic workspace session; the --agent flag is kept
+# as a naming hint so older examples keep working.
 # Exit codes: 0=success, 1=runtime error, 2=usage error
 set -euo pipefail
 
-# --- Preflight ---
-if ! command -v kocao &>/dev/null; then
-  echo "error: kocao binary not found in PATH" >&2
-  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
-  exit 2
-fi
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.opencode/skills/kocao-agent/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
 
-if ! command -v curl &>/dev/null; then
-  echo "error: curl is required but not found in PATH" >&2
-  exit 2
-fi
+usage() {
+  cat <<'EOF'
+Usage: agent-start.sh --repo <url> [--agent <name>] [--name <display-name>] [--quiet] [--no-wait] [--wait-timeout SEC]
 
-if ! command -v jq &>/dev/null; then
-  echo "error: jq is required but not found in PATH" >&2
-  exit 2
-fi
+Create a new workspace session.
 
-# --- Defaults ---
-REPO_URL=""
-AGENT="opencode"
-DISPLAY_NAME=""
-QUIET=false
-API_URL="${KOCAO_API_URL:-http://127.0.0.1:8080}"
-TOKEN="${KOCAO_TOKEN:-}"
-WAIT=true
-WAIT_TIMEOUT=120
+Options:
+  --repo URL          Repository URL to clone into the session (required)
+  --agent NAME        Session label for the intended agent workflow: opencode, codex, claude, pi
+  --name NAME         Explicit display name for the session
+  --quiet, -q         Output only the session ID
+  --no-wait           Return immediately after creation
+  --wait-timeout SEC  Max seconds to wait for the session to become Running
+  --help              Show this help
 
-# --- Parse args ---
-while [[ $# -gt 0 ]]; do
+Notes:
+  --agent is currently a display-name hint only. The control-plane API creates a
+  generic workspace session and does not switch runtime images based on this flag.
+EOF
+}
+
+require_commands kocao curl jq
+
+repo_url=""
+agent_label="opencode"
+display_name=""
+quiet=false
+wait_for_running=true
+wait_timeout=120
+api_response_file=""
+trap '[[ -n "$api_response_file" ]] && rm -f "$api_response_file"' EXIT
+
+while (($#)); do
   case "$1" in
     --repo)
-      REPO_URL="$2"
+      require_flag_value "$1" "$#"
+      repo_url="$2"
       shift 2
       ;;
     --agent)
-      AGENT="$2"
+      require_flag_value "$1" "$#"
+      agent_label="$2"
       shift 2
       ;;
     --name)
-      DISPLAY_NAME="$2"
+      require_flag_value "$1" "$#"
+      display_name="$2"
       shift 2
       ;;
     --quiet|-q)
-      QUIET=true
+      quiet=true
       shift
       ;;
     --no-wait)
-      WAIT=false
+      wait_for_running=false
       shift
       ;;
     --wait-timeout)
-      WAIT_TIMEOUT="$2"
+      require_flag_value "$1" "$#"
+      wait_timeout="$2"
+      require_positive_integer "$wait_timeout" "--wait-timeout"
       shift 2
       ;;
     --help|-h)
-      echo "Usage: agent-start.sh --repo <url> [--agent <name>] [--name <display-name>] [--quiet] [--no-wait]"
-      echo ""
-      echo "Create a new workspace session."
-      echo ""
-      echo "Options:"
-      echo "  --repo URL          Repository URL (required)"
-      echo "  --agent NAME        Agent type: opencode, codex, claude, pi (default: opencode)"
-      echo "  --name NAME         Display name for the session"
-      echo "  --quiet             Output only the session ID"
-      echo "  --no-wait           Don't wait for Running phase"
-      echo "  --wait-timeout SEC  Max seconds to wait for Running (default: 120)"
-      echo "  --help              Show this help"
+      usage
       exit 0
       ;;
+    -*)
+      usage_error "unknown flag: $1"
+      ;;
     *)
-      echo "error: unknown flag: $1" >&2
-      echo "Run with --help for usage" >&2
-      exit 2
+      usage_error "unexpected argument: $1"
       ;;
   esac
 done
 
-if [[ -z "$REPO_URL" ]]; then
-  echo "error: --repo is required" >&2
-  exit 2
-fi
-
-if [[ -z "$TOKEN" ]]; then
-  echo "error: KOCAO_TOKEN is not set" >&2
-  exit 2
-fi
-
-# Validate agent type
-case "$AGENT" in
+require_nonempty "$repo_url" "--repo"
+case "$agent_label" in
   opencode|codex|claude|pi) ;;
   *)
-    echo "error: unsupported agent type: $AGENT (expected: opencode, codex, claude, pi)" >&2
-    exit 2
+    usage_error "unsupported --agent value: ${agent_label} (expected: opencode, codex, claude, pi)"
     ;;
 esac
 
-# --- Build request ---
-if [[ -z "$DISPLAY_NAME" ]]; then
-  DISPLAY_NAME="${AGENT}-$(date +%s)"
+if [[ -z "$display_name" ]]; then
+  display_name="${agent_label}-$(date +%s)"
 fi
 
-PAYLOAD=$(jq -n \
-  --arg displayName "$DISPLAY_NAME" \
-  --arg repoURL "$REPO_URL" \
-  --arg agent "$AGENT" \
-  '{displayName: $displayName, repoURL: $repoURL, agent: $agent}')
-
-# --- Create session ---
-API_URL="${API_URL%/}"
-RESPONSE=$(curl -s -w "\n%{http_code}" \
-  -X POST \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json" \
-  -d "$PAYLOAD" \
-  "${API_URL}/api/v1/workspace-sessions" \
-  2>&1) || {
-  echo "error: failed to call control-plane API" >&2
-  exit 1
-}
-
-HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-BODY=$(echo "$RESPONSE" | sed '$d')
-
-if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
-  echo "error: API returned HTTP ${HTTP_CODE}" >&2
-  echo "$BODY" >&2
+payload="$(jq -n --arg displayName "$display_name" --arg repoURL "$repo_url" '{displayName: $displayName, repoURL: $repoURL}')"
+api_request POST '/api/v1/workspace-sessions' "$payload"
+api_response_file="$API_RESPONSE_FILE"
+if ! api_request_ok; then
+  print_api_error "$API_RESPONSE_CODE" "$API_RESPONSE_FILE"
   exit 1
 fi
 
-SESSION_ID=$(echo "$BODY" | jq -r '.id // empty' 2>/dev/null)
-if [[ -z "$SESSION_ID" ]]; then
-  echo "error: could not extract session ID from response" >&2
-  echo "$BODY" >&2
+session_id="$(jq -r '.id // empty' "$API_RESPONSE_FILE" 2>/dev/null)"
+if [[ -z "$session_id" ]]; then
+  echo 'error: create response did not include a session id' >&2
+  print_json_or_raw "$API_RESPONSE_FILE" >&2 || true
   exit 1
 fi
 
-# --- Wait for Running (optional) ---
-if [[ "$WAIT" == true ]]; then
-  ELAPSED=0
-  while [[ $ELAPSED -lt $WAIT_TIMEOUT ]]; do
-    STATUS_JSON=$(kocao sessions status "$SESSION_ID" --json 2>/dev/null) || true
-    PHASE=$(echo "$STATUS_JSON" | jq -r '.session.phase // empty' 2>/dev/null)
-    case "$PHASE" in
+final_output="$API_RESPONSE_FILE"
+if [[ "$wait_for_running" == true ]]; then
+  elapsed=0
+  current_phase=""
+  while (( elapsed < wait_timeout )); do
+    status_json="$(kocao sessions status "$session_id" --json 2>/dev/null || true)"
+    current_phase="$(jq -r '.session.phase // empty' <<<"$status_json" 2>/dev/null || true)"
+    case "$current_phase" in
       Running)
+        status_file="$(mktemp)"
+        printf '%s' "$status_json" > "$status_file"
+        final_output="$status_file"
+        api_response_file="$status_file"
         break
         ;;
       Failed)
-        echo "error: session entered Failed phase" >&2
-        echo "$STATUS_JSON" | jq . >&2 2>/dev/null || echo "$STATUS_JSON" >&2
+        echo "error: session ${session_id} entered Failed phase" >&2
+        if [[ -n "$status_json" ]]; then
+          jq . <<<"$status_json" >&2 2>/dev/null || echo "$status_json" >&2
+        fi
         exit 1
         ;;
     esac
     sleep 3
-    ELAPSED=$((ELAPSED + 3))
+    elapsed=$((elapsed + 3))
   done
 
-  if [[ $ELAPSED -ge $WAIT_TIMEOUT ]]; then
-    echo "warning: timed out waiting for Running phase (current: ${PHASE:-unknown})" >&2
+  if (( elapsed >= wait_timeout )) && [[ "$current_phase" != "Running" ]]; then
+    echo "warning: timed out waiting for session ${session_id} to reach Running (current: ${current_phase:-unknown})" >&2
   fi
 fi
 
-# --- Output ---
-if [[ "$QUIET" == true ]]; then
-  echo "$SESSION_ID"
+if [[ "$quiet" == true ]]; then
+  echo "$session_id"
 else
-  echo "$BODY" | jq . 2>/dev/null || echo "$BODY"
+  print_json_or_raw "$final_output"
 fi

--- a/.opencode/skills/kocao-agent/scripts/agent-status.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-status.sh
@@ -4,65 +4,57 @@
 # Exit codes: 0=success, 1=runtime error, 2=usage error
 set -euo pipefail
 
-# --- Preflight ---
-if ! command -v kocao &>/dev/null; then
-  echo "error: kocao binary not found in PATH" >&2
-  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
-  exit 2
-fi
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.opencode/skills/kocao-agent/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
 
-# --- Defaults ---
-SESSION_ID=""
-JSON_OUT=true
+usage() {
+  cat <<'EOF'
+Usage: agent-status.sh <session-id> [--no-json]
 
-# --- Parse args ---
-while [[ $# -gt 0 ]]; do
+Get detailed status for a workspace session.
+
+Arguments:
+  session-id    Workspace session ID
+
+Options:
+  --no-json     Output the default kocao text format instead of JSON
+  --help        Show this help
+EOF
+}
+
+require_commands kocao
+
+session_id=""
+json_out=true
+while (($#)); do
   case "$1" in
     --no-json)
-      JSON_OUT=false
+      json_out=false
       shift
       ;;
     --help|-h)
-      echo "Usage: agent-status.sh <session-id> [--no-json]"
-      echo ""
-      echo "Get detailed status of a workspace session."
-      echo ""
-      echo "Arguments:"
-      echo "  session-id    Workspace session ID"
-      echo ""
-      echo "Options:"
-      echo "  --no-json     Output human-readable text instead of JSON"
-      echo "  --help        Show this help"
+      usage
       exit 0
       ;;
     -*)
-      echo "error: unknown flag: $1" >&2
-      exit 2
+      usage_error "unknown flag: $1"
       ;;
     *)
-      if [[ -z "$SESSION_ID" ]]; then
-        SESSION_ID="$1"
-      else
-        echo "error: unexpected argument: $1" >&2
-        exit 2
+      if [[ -n "$session_id" ]]; then
+        usage_error "unexpected argument: $1"
       fi
+      session_id="$1"
       shift
       ;;
   esac
 done
 
-if [[ -z "$SESSION_ID" ]]; then
-  echo "error: session-id is required" >&2
-  echo "Usage: agent-status.sh <session-id>" >&2
-  exit 2
+require_nonempty "$session_id" "session-id"
+
+cmd=(kocao sessions status "$session_id")
+if [[ "$json_out" == true ]]; then
+  cmd+=(--json)
 fi
 
-# --- Build command ---
-CMD=(kocao sessions status "$SESSION_ID")
-
-if [[ "$JSON_OUT" == true ]]; then
-  CMD+=(--json)
-fi
-
-# --- Execute ---
-exec "${CMD[@]}"
+exec "${cmd[@]}"

--- a/.opencode/skills/kocao-agent/scripts/agent-status.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-status.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# agent-status.sh — Get detailed status of a workspace session.
+# Wraps: kocao sessions status <id> --json
+# Exit codes: 0=success, 1=runtime error, 2=usage error
+set -euo pipefail
+
+# --- Preflight ---
+if ! command -v kocao &>/dev/null; then
+  echo "error: kocao binary not found in PATH" >&2
+  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
+  exit 2
+fi
+
+# --- Defaults ---
+SESSION_ID=""
+JSON_OUT=true
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-json)
+      JSON_OUT=false
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: agent-status.sh <session-id> [--no-json]"
+      echo ""
+      echo "Get detailed status of a workspace session."
+      echo ""
+      echo "Arguments:"
+      echo "  session-id    Workspace session ID"
+      echo ""
+      echo "Options:"
+      echo "  --no-json     Output human-readable text instead of JSON"
+      echo "  --help        Show this help"
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$SESSION_ID" ]]; then
+        SESSION_ID="$1"
+      else
+        echo "error: unexpected argument: $1" >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$SESSION_ID" ]]; then
+  echo "error: session-id is required" >&2
+  echo "Usage: agent-status.sh <session-id>" >&2
+  exit 2
+fi
+
+# --- Build command ---
+CMD=(kocao sessions status "$SESSION_ID")
+
+if [[ "$JSON_OUT" == true ]]; then
+  CMD+=(--json)
+fi
+
+# --- Execute ---
+exec "${CMD[@]}"

--- a/.opencode/skills/kocao-agent/scripts/agent-stop.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-stop.sh
@@ -3,104 +3,70 @@
 # Exit codes: 0=success, 1=runtime error, 2=usage error
 set -euo pipefail
 
-# --- Preflight ---
-if ! command -v kocao &>/dev/null; then
-  echo "error: kocao binary not found in PATH" >&2
-  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
-  exit 2
-fi
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.opencode/skills/kocao-agent/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
 
-if ! command -v curl &>/dev/null; then
-  echo "error: curl is required but not found in PATH" >&2
-  exit 2
-fi
+usage() {
+  cat <<'EOF'
+Usage: agent-stop.sh <session-id> [--no-json]
 
-if ! command -v jq &>/dev/null; then
-  echo "error: jq is required but not found in PATH" >&2
-  exit 2
-fi
+Stop a workspace session.
 
-# --- Defaults ---
-SESSION_ID=""
-API_URL="${KOCAO_API_URL:-http://127.0.0.1:8080}"
-TOKEN="${KOCAO_TOKEN:-}"
-OUTPUT_JSON=true
+Arguments:
+  session-id    Workspace session ID to stop
 
-# --- Parse args ---
-while [[ $# -gt 0 ]]; do
+Options:
+  --no-json     Output a short confirmation line instead of JSON
+  --help        Show this help
+EOF
+}
+
+require_commands curl jq
+
+session_id=""
+json_out=true
+api_response_file=""
+trap '[[ -n "$api_response_file" ]] && rm -f "$api_response_file"' EXIT
+
+while (($#)); do
   case "$1" in
     --no-json)
-      OUTPUT_JSON=false
+      json_out=false
       shift
       ;;
     --help|-h)
-      echo "Usage: agent-stop.sh <session-id> [--no-json]"
-      echo ""
-      echo "Stop a workspace session."
-      echo ""
-      echo "Arguments:"
-      echo "  session-id    Workspace session ID to stop"
-      echo ""
-      echo "Options:"
-      echo "  --no-json     Output human-readable text instead of JSON"
-      echo "  --help        Show this help"
+      usage
       exit 0
       ;;
     -*)
-      echo "error: unknown flag: $1" >&2
-      exit 2
+      usage_error "unknown flag: $1"
       ;;
     *)
-      if [[ -z "$SESSION_ID" ]]; then
-        SESSION_ID="$1"
-      else
-        echo "error: unexpected argument: $1" >&2
-        exit 2
+      if [[ -n "$session_id" ]]; then
+        usage_error "unexpected argument: $1"
       fi
+      session_id="$1"
       shift
       ;;
   esac
 done
 
-if [[ -z "$SESSION_ID" ]]; then
-  echo "error: session-id is required" >&2
-  echo "Usage: agent-stop.sh <session-id>" >&2
-  exit 2
-fi
+require_nonempty "$session_id" "session-id"
 
-if [[ -z "$TOKEN" ]]; then
-  echo "error: KOCAO_TOKEN is not set" >&2
-  exit 2
-fi
-
-# --- Stop session ---
-API_URL="${API_URL%/}"
-RESPONSE=$(curl -s -w "\n%{http_code}" \
-  -X DELETE \
-  -H "Authorization: Bearer ${TOKEN}" \
-  -H "Accept: application/json" \
-  "${API_URL}/api/v1/workspace-sessions/$(printf '%s' "$SESSION_ID" | jq -sRr @uri)" \
-  2>&1) || {
-  echo "error: failed to call control-plane API" >&2
-  exit 1
-}
-
-HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-BODY=$(echo "$RESPONSE" | sed '$d')
-
-if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
-  echo "error: API returned HTTP ${HTTP_CODE}" >&2
-  echo "$BODY" >&2
+api_request DELETE "/api/v1/workspace-sessions/$(urlencode "$session_id")"
+api_response_file="$API_RESPONSE_FILE"
+if ! api_request_ok; then
+  print_api_error "$API_RESPONSE_CODE" "$API_RESPONSE_FILE"
   exit 1
 fi
 
-# --- Output ---
-if [[ "$OUTPUT_JSON" == true ]]; then
-  if [[ -n "$BODY" ]]; then
-    echo "$BODY" | jq . 2>/dev/null || jq -n --arg sid "$SESSION_ID" '{status:"stopped",sessionId:$sid}'
+if [[ "$json_out" == true ]]; then
+  if [[ -s "$API_RESPONSE_FILE" ]]; then
+    print_json_or_raw "$API_RESPONSE_FILE"
   else
-    jq -n --arg sid "$SESSION_ID" '{status:"stopped",sessionId:$sid}'
+    jq -n --arg sid "$session_id" '{status:"stopped",sessionId:$sid}'
   fi
 else
-  echo "Stopped session: ${SESSION_ID}"
+  echo "Stopped session: ${session_id}"
 fi

--- a/.opencode/skills/kocao-agent/scripts/agent-stop.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-stop.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# agent-stop.sh — Stop/terminate a workspace session via the kocao control-plane API.
+# Exit codes: 0=success, 1=runtime error, 2=usage error
+set -euo pipefail
+
+# --- Preflight ---
+if ! command -v kocao &>/dev/null; then
+  echo "error: kocao binary not found in PATH" >&2
+  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
+  exit 2
+fi
+
+if ! command -v curl &>/dev/null; then
+  echo "error: curl is required but not found in PATH" >&2
+  exit 2
+fi
+
+# --- Defaults ---
+SESSION_ID=""
+API_URL="${KOCAO_API_URL:-http://127.0.0.1:8080}"
+TOKEN="${KOCAO_TOKEN:-}"
+OUTPUT_JSON=true
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-json)
+      OUTPUT_JSON=false
+      shift
+      ;;
+    --help|-h)
+      echo "Usage: agent-stop.sh <session-id> [--no-json]"
+      echo ""
+      echo "Stop a workspace session."
+      echo ""
+      echo "Arguments:"
+      echo "  session-id    Workspace session ID to stop"
+      echo ""
+      echo "Options:"
+      echo "  --no-json     Output human-readable text instead of JSON"
+      echo "  --help        Show this help"
+      exit 0
+      ;;
+    -*)
+      echo "error: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      if [[ -z "$SESSION_ID" ]]; then
+        SESSION_ID="$1"
+      else
+        echo "error: unexpected argument: $1" >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$SESSION_ID" ]]; then
+  echo "error: session-id is required" >&2
+  echo "Usage: agent-stop.sh <session-id>" >&2
+  exit 2
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  echo "error: KOCAO_TOKEN is not set" >&2
+  exit 2
+fi
+
+# --- Stop session ---
+API_URL="${API_URL%/}"
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+  -X DELETE \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/json" \
+  "${API_URL}/api/v1/workspace-sessions/$(printf '%s' "$SESSION_ID" | jq -sRr @uri)" \
+  2>&1) || {
+  echo "error: failed to call control-plane API" >&2
+  exit 1
+}
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  echo "error: API returned HTTP ${HTTP_CODE}" >&2
+  echo "$BODY" >&2
+  exit 1
+fi
+
+# --- Output ---
+if [[ "$OUTPUT_JSON" == true ]]; then
+  if [[ -n "$BODY" ]]; then
+    echo "$BODY" | jq . 2>/dev/null || echo "{\"status\":\"stopped\",\"sessionId\":\"${SESSION_ID}\"}"
+  else
+    echo "{\"status\":\"stopped\",\"sessionId\":\"${SESSION_ID}\"}"
+  fi
+else
+  echo "Stopped session: ${SESSION_ID}"
+fi

--- a/.opencode/skills/kocao-agent/scripts/agent-stop.sh
+++ b/.opencode/skills/kocao-agent/scripts/agent-stop.sh
@@ -15,6 +15,11 @@ if ! command -v curl &>/dev/null; then
   exit 2
 fi
 
+if ! command -v jq &>/dev/null; then
+  echo "error: jq is required but not found in PATH" >&2
+  exit 2
+fi
+
 # --- Defaults ---
 SESSION_ID=""
 API_URL="${KOCAO_API_URL:-http://127.0.0.1:8080}"
@@ -92,9 +97,9 @@ fi
 # --- Output ---
 if [[ "$OUTPUT_JSON" == true ]]; then
   if [[ -n "$BODY" ]]; then
-    echo "$BODY" | jq . 2>/dev/null || echo "{\"status\":\"stopped\",\"sessionId\":\"${SESSION_ID}\"}"
+    echo "$BODY" | jq . 2>/dev/null || jq -n --arg sid "$SESSION_ID" '{status:"stopped",sessionId:$sid}'
   else
-    echo "{\"status\":\"stopped\",\"sessionId\":\"${SESSION_ID}\"}"
+    jq -n --arg sid "$SESSION_ID" '{status:"stopped",sessionId:$sid}'
   fi
 else
   echo "Stopped session: ${SESSION_ID}"

--- a/.opencode/skills/kocao-agent/scripts/common.sh
+++ b/.opencode/skills/kocao-agent/scripts/common.sh
@@ -137,7 +137,7 @@ api_request() {
     } >>"$config_file"
   fi
 
-  status_code="$(curl -sS -o "$body_file" -w '%{http_code}' --config "$config_file")" || {
+  status_code="$(curl -sS -o "$body_file" -w '%{http_code}' --connect-timeout "${KOCAO_CURL_CONNECT_TIMEOUT:-10}" --max-time "${KOCAO_CURL_MAX_TIMEOUT:-30}" --config "$config_file")" || {
     rm -f "$body_file"
     fail "failed to reach $(api_base_url). Check KOCAO_API_URL and your network connection."
   }

--- a/.opencode/skills/kocao-agent/scripts/common.sh
+++ b/.opencode/skills/kocao-agent/scripts/common.sh
@@ -66,14 +66,33 @@ require_positive_integer() {
   fi
 }
 
-require_token() {
-  if [[ -z "${KOCAO_TOKEN:-}" ]]; then
-    usage_error "KOCAO_TOKEN is not set. Export KOCAO_TOKEN or configure ~/.config/kocao/settings.json."
+_config_value() {
+  local key="$1"
+  local config_file="${HOME}/.config/kocao/settings.json"
+  if [[ -f "$config_file" ]]; then
+    jq -r --arg k "$key" '.[$k] // empty' "$config_file" 2>/dev/null || true
   fi
 }
 
+require_token() {
+  if [[ -n "${KOCAO_TOKEN:-}" ]]; then
+    return
+  fi
+  local cfg_token
+  cfg_token="$(_config_value token)"
+  if [[ -n "$cfg_token" ]]; then
+    export KOCAO_TOKEN="$cfg_token"
+    return
+  fi
+  usage_error "KOCAO_TOKEN is not set. Export KOCAO_TOKEN or configure ~/.config/kocao/settings.json."
+}
+
 api_base_url() {
-  local url="${KOCAO_API_URL:-http://127.0.0.1:8080}"
+  local url="${KOCAO_API_URL:-}"
+  if [[ -z "$url" ]]; then
+    url="$(_config_value api_url)"
+  fi
+  url="${url:-http://127.0.0.1:8080}"
   printf '%s\n' "${url%/}"
 }
 
@@ -119,7 +138,9 @@ api_request() {
   body_file="$(mktemp)"
   config_file="$(mktemp)"
   payload_file=""
-  trap 'rm -f "$config_file" "$payload_file"' RETURN
+  # Use both RETURN (for normal returns) and a cleanup helper for fail/exit paths.
+  _api_request_cleanup() { rm -f "$config_file" "$payload_file"; }
+  trap '_api_request_cleanup' RETURN
 
   {
     printf 'url = "%s"\n' "$url"
@@ -139,6 +160,7 @@ api_request() {
 
   status_code="$(curl -sS -o "$body_file" -w '%{http_code}' --connect-timeout "${KOCAO_CURL_CONNECT_TIMEOUT:-10}" --max-time "${KOCAO_CURL_MAX_TIMEOUT:-30}" --config "$config_file")" || {
     rm -f "$body_file"
+    _api_request_cleanup  # RETURN trap won't fire when fail calls exit
     fail "failed to reach $(api_base_url). Check KOCAO_API_URL and your network connection."
   }
 

--- a/.opencode/skills/kocao-agent/scripts/common.sh
+++ b/.opencode/skills/kocao-agent/scripts/common.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+
+API_RESPONSE_FILE=""
+API_RESPONSE_CODE=""
+
+script_name() {
+  basename -- "$0"
+}
+
+print_kocao_install_hint() {
+  echo "Install: go install github.com/withakay/kocao/cmd/kocao@latest" >&2
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+usage_error() {
+  echo "error: $*" >&2
+  echo "Run $(script_name) --help for usage." >&2
+  exit 2
+}
+
+require_command() {
+  local command_name="$1"
+  if command -v "$command_name" >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "error: required command not found: $command_name" >&2
+  if [[ "$command_name" == "kocao" ]]; then
+    print_kocao_install_hint
+  fi
+  exit 2
+}
+
+require_commands() {
+  local command_name
+  for command_name in "$@"; do
+    require_command "$command_name"
+  done
+}
+
+require_flag_value() {
+  local flag="$1"
+  local argc="$2"
+  if (( argc < 2 )); then
+    usage_error "missing value for ${flag}"
+  fi
+}
+
+require_nonempty() {
+  local value="$1"
+  local label="$2"
+  if [[ -z "$value" ]]; then
+    usage_error "${label} is required"
+  fi
+}
+
+require_positive_integer() {
+  local value="$1"
+  local label="$2"
+  if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+    usage_error "${label} must be a positive integer"
+  fi
+}
+
+require_token() {
+  if [[ -z "${KOCAO_TOKEN:-}" ]]; then
+    usage_error "KOCAO_TOKEN is not set. Export KOCAO_TOKEN or configure ~/.config/kocao/settings.json."
+  fi
+}
+
+api_base_url() {
+  local url="${KOCAO_API_URL:-http://127.0.0.1:8080}"
+  printf '%s\n' "${url%/}"
+}
+
+urlencode() {
+  jq -nr --arg value "$1" '$value|@uri'
+}
+
+json_error_message() {
+  local file="$1"
+  jq -r '.error // empty' "$file" 2>/dev/null || true
+}
+
+print_json_or_raw() {
+  local file="$1"
+  if [[ ! -s "$file" ]]; then
+    return
+  fi
+  jq . "$file" 2>/dev/null || cat "$file"
+}
+
+print_api_error() {
+  local status_code="$1"
+  local body_file="$2"
+  local api_message
+
+  api_message="$(json_error_message "$body_file")"
+  echo "error: API returned HTTP ${status_code}" >&2
+  if [[ -n "$api_message" ]]; then
+    echo "$api_message" >&2
+  elif [[ -s "$body_file" ]]; then
+    cat "$body_file" >&2
+  fi
+}
+
+api_request() {
+  local method="$1"
+  local route="$2"
+  local payload="${3-}"
+  local body_file url status_code config_file payload_file
+
+  require_token
+  url="$(api_base_url)${route}"
+  body_file="$(mktemp)"
+  config_file="$(mktemp)"
+  payload_file=""
+  trap 'rm -f "$config_file" "$payload_file"' RETURN
+
+  {
+    printf 'url = "%s"\n' "$url"
+    printf 'request = "%s"\n' "$method"
+    printf 'header = "Authorization: Bearer %s"\n' "$KOCAO_TOKEN"
+    printf 'header = "Accept: application/json"\n'
+  } >"$config_file"
+
+  if [[ -n "$payload" ]]; then
+    payload_file="$(mktemp)"
+    printf '%s' "$payload" >"$payload_file"
+    {
+      printf 'header = "Content-Type: application/json"\n'
+      printf 'data = @"%s"\n' "$payload_file"
+    } >>"$config_file"
+  fi
+
+  status_code="$(curl -sS -o "$body_file" -w '%{http_code}' --config "$config_file")" || {
+    rm -f "$body_file"
+    fail "failed to reach $(api_base_url). Check KOCAO_API_URL and your network connection."
+  }
+
+  # shellcheck disable=SC2034
+  API_RESPONSE_FILE="$body_file"
+  API_RESPONSE_CODE="$status_code"
+}
+
+api_request_ok() {
+  [[ "${API_RESPONSE_CODE:-}" =~ ^[0-9]{3}$ ]] || fail "received an invalid HTTP status from the API: ${API_RESPONSE_CODE:-<empty>}"
+  (( 10#${API_RESPONSE_CODE} >= 200 && 10#${API_RESPONSE_CODE} < 300 ))
+}

--- a/docs/demos/agent-skill-remote-management.md
+++ b/docs/demos/agent-skill-remote-management.md
@@ -1,0 +1,196 @@
+# Demo: AI Assistant Managing Remote Agents
+
+This demo shows an AI assistant (OpenCode) using the `kocao-agent` skill to
+manage remote coding agents on a Kocao cluster.
+
+## Prerequisites
+
+- Kocao cluster deployed and accessible
+- `kocao` CLI installed and configured (`KOCAO_API_URL`, `KOCAO_TOKEN`)
+- OpenCode with the `kocao-agent` skill loaded
+
+---
+
+## Scene 1: Start a remote agent
+
+**User:** Start a codex agent on the cluster to work on the kocao repo.
+
+**Assistant:** Starting a codex agent for the kocao repository.
+
+```bash
+$ .opencode/skills/kocao-agent/scripts/agent-start.sh \
+    --repo https://github.com/withakay/kocao \
+    --agent codex
+```
+
+```json
+{
+  "id": "ws-a1b2c3d4",
+  "displayName": "codex-1712937600",
+  "repoURL": "https://github.com/withakay/kocao",
+  "phase": "Running",
+  "createdAt": "2026-04-12T10:00:00Z"
+}
+```
+
+**Assistant:** Session `ws-a1b2c3d4` is running. The codex agent is ready and
+has cloned the repository.
+
+---
+
+## Scene 2: Send a task to the agent
+
+**User:** Ask it to review the README and suggest improvements.
+
+**Assistant:** Sending the task to the remote agent.
+
+```bash
+$ .opencode/skills/kocao-agent/scripts/agent-exec.sh ws-a1b2c3d4 \
+    --prompt "Review the README.md file and suggest improvements for clarity, completeness, and developer experience."
+```
+
+```json
+{
+  "status": "sent",
+  "sessionId": "ws-a1b2c3d4"
+}
+```
+
+**Assistant:** Task sent to agent `ws-a1b2c3d4`. The codex agent is now
+reviewing the README. Let me check on its progress.
+
+---
+
+## Scene 3: Check agent status
+
+**User:** How is it doing?
+
+**Assistant:** Checking the agent status.
+
+```bash
+$ .opencode/skills/kocao-agent/scripts/agent-status.sh ws-a1b2c3d4
+```
+
+```json
+{
+  "session": {
+    "id": "ws-a1b2c3d4",
+    "displayName": "codex-1712937600",
+    "phase": "Running",
+    "repoURL": "https://github.com/withakay/kocao",
+    "createdAt": "2026-04-12T10:00:00Z"
+  },
+  "run": {
+    "id": "hr-e5f6g7h8",
+    "phase": "Running",
+    "podName": "harness-ws-a1b2c3d4-xk9m2"
+  }
+}
+```
+
+**Assistant:** Agent `ws-a1b2c3d4` is still running. The harness run `hr-e5f6g7h8`
+is active in pod `harness-ws-a1b2c3d4-xk9m2`.
+
+---
+
+## Scene 4: View agent logs
+
+**User:** Show me what it's been doing.
+
+**Assistant:** Fetching the last 50 lines of logs.
+
+```bash
+$ .opencode/skills/kocao-agent/scripts/agent-logs.sh ws-a1b2c3d4 --tail 50 --no-json
+```
+
+```
+[agent] Cloned https://github.com/withakay/kocao (branch: main)
+[agent] Analyzing README.md...
+[agent] Found 3 areas for improvement:
+[agent]   1. Missing quickstart section
+[agent]   2. Installation instructions reference deprecated flag
+[agent]   3. API reference section is incomplete
+[agent] Generating suggestions...
+[agent] Creating branch: readme-improvements
+[agent] Committing changes...
+[agent] Opening pull request...
+[agent] PR created: #47 "Improve README clarity and completeness"
+[agent] Task complete.
+```
+
+**Assistant:** The codex agent has completed its review. It found 3 areas for
+improvement and created PR #47 with the suggested changes.
+
+---
+
+## Scene 5: List all running agents
+
+**User:** What other agents are running?
+
+**Assistant:** Listing all active sessions.
+
+```bash
+$ .opencode/skills/kocao-agent/scripts/agent-list.sh
+```
+
+```json
+{
+  "workspaceSessions": [
+    {
+      "id": "ws-a1b2c3d4",
+      "displayName": "codex-1712937600",
+      "phase": "Running",
+      "createdAt": "2026-04-12T10:00:00Z"
+    },
+    {
+      "id": "ws-z9y8x7w6",
+      "displayName": "opencode-api-tests",
+      "phase": "Running",
+      "createdAt": "2026-04-12T09:30:00Z"
+    }
+  ]
+}
+```
+
+**Assistant:** There are 2 active sessions:
+1. `ws-a1b2c3d4` (codex) — the one we started for README review
+2. `ws-z9y8x7w6` (opencode) — running API tests, started 30 minutes ago
+
+---
+
+## Scene 6: Stop the agent
+
+**User:** The codex agent is done. Stop it.
+
+**Assistant:** Stopping the codex session.
+
+```bash
+$ .opencode/skills/kocao-agent/scripts/agent-stop.sh ws-a1b2c3d4
+```
+
+```json
+{
+  "status": "stopped",
+  "sessionId": "ws-a1b2c3d4"
+}
+```
+
+**Assistant:** Session `ws-a1b2c3d4` has been stopped. The codex agent's work
+(PR #47) is preserved in GitHub.
+
+---
+
+## Summary
+
+This demo showed the full lifecycle of managing a remote coding agent:
+
+1. **Start** — Created a codex agent session on the cluster
+2. **Exec** — Sent a review task to the running agent
+3. **Status** — Checked the agent's current phase and run info
+4. **Logs** — Viewed the agent's output and progress
+5. **List** — Saw all active agent sessions
+6. **Stop** — Terminated the completed session
+
+The `kocao-agent` skill provides an AI assistant with full control over remote
+coding agents, enabling multi-agent workflows where tasks are distributed
+across specialized agents running in isolated Kubernetes pods.

--- a/docs/demos/agent-skill-remote-management.md
+++ b/docs/demos/agent-skill-remote-management.md
@@ -18,7 +18,7 @@ Kocao workspace sessions.
 **Assistant:** Creating a workspace session for the kocao repository.
 
 ```bash
-$ .opencode/skills/kocao-agent/scripts/agent-start.sh \
+.opencode/skills/kocao-agent/scripts/agent-start.sh \
     --repo https://github.com/withakay/kocao \
     --agent codex
 ```
@@ -52,7 +52,7 @@ session easy to identify, and the harness pod is ready.
 **Assistant:** Sending the task through the exec endpoint.
 
 ```bash
-$ .opencode/skills/kocao-agent/scripts/agent-exec.sh ws-a1b2c3d4 \
+.opencode/skills/kocao-agent/scripts/agent-exec.sh ws-a1b2c3d4 \
     --prompt "Review the README.md file and suggest improvements for clarity, completeness, and developer experience."
 ```
 
@@ -75,7 +75,7 @@ support `/exec`, I would fall back to `kocao sessions attach ... --driver`.
 **Assistant:** Checking the session status.
 
 ```bash
-$ .opencode/skills/kocao-agent/scripts/agent-status.sh ws-a1b2c3d4
+.opencode/skills/kocao-agent/scripts/agent-status.sh ws-a1b2c3d4
 ```
 
 ```json
@@ -106,7 +106,7 @@ $ .opencode/skills/kocao-agent/scripts/agent-status.sh ws-a1b2c3d4
 **Assistant:** Fetching the last 50 log lines.
 
 ```bash
-$ .opencode/skills/kocao-agent/scripts/agent-logs.sh ws-a1b2c3d4 --tail 50 --no-json
+.opencode/skills/kocao-agent/scripts/agent-logs.sh ws-a1b2c3d4 --tail 50 --no-json
 ```
 
 ```text
@@ -129,7 +129,7 @@ $ .opencode/skills/kocao-agent/scripts/agent-logs.sh ws-a1b2c3d4 --tail 50 --no-
 **Assistant:** Listing active sessions.
 
 ```bash
-$ .opencode/skills/kocao-agent/scripts/agent-list.sh
+.opencode/skills/kocao-agent/scripts/agent-list.sh
 ```
 
 ```json
@@ -160,7 +160,7 @@ $ .opencode/skills/kocao-agent/scripts/agent-list.sh
 **Assistant:** Stopping the workspace session.
 
 ```bash
-$ .opencode/skills/kocao-agent/scripts/agent-stop.sh ws-a1b2c3d4
+.opencode/skills/kocao-agent/scripts/agent-stop.sh ws-a1b2c3d4
 ```
 
 ```json

--- a/docs/demos/agent-skill-remote-management.md
+++ b/docs/demos/agent-skill-remote-management.md
@@ -1,21 +1,21 @@
-# Demo: AI Assistant Managing Remote Agents
+# Demo: AI Assistant Managing Remote Sessions
 
-This demo shows an AI assistant (OpenCode) using the `kocao-agent` skill to
-manage remote coding agents on a Kocao cluster.
+This demo shows an AI assistant using the `kocao-agent` skill to manage remote
+Kocao workspace sessions.
 
 ## Prerequisites
 
-- Kocao cluster deployed and accessible
+- Kocao cluster deployed and reachable
 - `kocao` CLI installed and configured (`KOCAO_API_URL`, `KOCAO_TOKEN`)
 - OpenCode with the `kocao-agent` skill loaded
 
 ---
 
-## Scene 1: Start a remote agent
+## Scene 1: Start a remote session
 
-**User:** Start a codex agent on the cluster to work on the kocao repo.
+**User:** Start a remote session for the kocao repo and label it for codex work.
 
-**Assistant:** Starting a codex agent for the kocao repository.
+**Assistant:** Creating a workspace session for the kocao repository.
 
 ```bash
 $ .opencode/skills/kocao-agent/scripts/agent-start.sh \
@@ -25,24 +25,31 @@ $ .opencode/skills/kocao-agent/scripts/agent-start.sh \
 
 ```json
 {
-  "id": "ws-a1b2c3d4",
-  "displayName": "codex-1712937600",
-  "repoURL": "https://github.com/withakay/kocao",
-  "phase": "Running",
-  "createdAt": "2026-04-12T10:00:00Z"
+  "session": {
+    "id": "ws-a1b2c3d4",
+    "displayName": "codex-1712937600",
+    "phase": "Running",
+    "repoURL": "https://github.com/withakay/kocao",
+    "createdAt": "2026-04-12T10:00:00Z"
+  },
+  "run": {
+    "id": "hr-e5f6g7h8",
+    "phase": "Running",
+    "podName": "harness-ws-a1b2c3d4-xk9m2"
+  }
 }
 ```
 
-**Assistant:** Session `ws-a1b2c3d4` is running. The codex agent is ready and
-has cloned the repository.
+**Assistant:** Session `ws-a1b2c3d4` is running. The `codex` label makes the
+session easy to identify, and the harness pod is ready.
 
 ---
 
-## Scene 2: Send a task to the agent
+## Scene 2: Send a task to the session
 
 **User:** Ask it to review the README and suggest improvements.
 
-**Assistant:** Sending the task to the remote agent.
+**Assistant:** Sending the task through the exec endpoint.
 
 ```bash
 $ .opencode/skills/kocao-agent/scripts/agent-exec.sh ws-a1b2c3d4 \
@@ -56,16 +63,16 @@ $ .opencode/skills/kocao-agent/scripts/agent-exec.sh ws-a1b2c3d4 \
 }
 ```
 
-**Assistant:** Task sent to agent `ws-a1b2c3d4`. The codex agent is now
-reviewing the README. Let me check on its progress.
+**Assistant:** Task sent to session `ws-a1b2c3d4`. If the control-plane did not
+support `/exec`, I would fall back to `kocao sessions attach ... --driver`.
 
 ---
 
-## Scene 3: Check agent status
+## Scene 3: Check session status
 
 **User:** How is it doing?
 
-**Assistant:** Checking the agent status.
+**Assistant:** Checking the session status.
 
 ```bash
 $ .opencode/skills/kocao-agent/scripts/agent-status.sh ws-a1b2c3d4
@@ -88,22 +95,21 @@ $ .opencode/skills/kocao-agent/scripts/agent-status.sh ws-a1b2c3d4
 }
 ```
 
-**Assistant:** Agent `ws-a1b2c3d4` is still running. The harness run `hr-e5f6g7h8`
-is active in pod `harness-ws-a1b2c3d4-xk9m2`.
+**Assistant:** The session is still active and the harness run is healthy.
 
 ---
 
-## Scene 4: View agent logs
+## Scene 4: View logs
 
 **User:** Show me what it's been doing.
 
-**Assistant:** Fetching the last 50 lines of logs.
+**Assistant:** Fetching the last 50 log lines.
 
 ```bash
 $ .opencode/skills/kocao-agent/scripts/agent-logs.sh ws-a1b2c3d4 --tail 50 --no-json
 ```
 
-```
+```text
 [agent] Cloned https://github.com/withakay/kocao (branch: main)
 [agent] Analyzing README.md...
 [agent] Found 3 areas for improvement:
@@ -111,23 +117,16 @@ $ .opencode/skills/kocao-agent/scripts/agent-logs.sh ws-a1b2c3d4 --tail 50 --no-
 [agent]   2. Installation instructions reference deprecated flag
 [agent]   3. API reference section is incomplete
 [agent] Generating suggestions...
-[agent] Creating branch: readme-improvements
-[agent] Committing changes...
-[agent] Opening pull request...
-[agent] PR created: #47 "Improve README clarity and completeness"
 [agent] Task complete.
 ```
 
-**Assistant:** The codex agent has completed its review. It found 3 areas for
-improvement and created PR #47 with the suggested changes.
-
 ---
 
-## Scene 5: List all running agents
+## Scene 5: List active sessions
 
-**User:** What other agents are running?
+**User:** What other sessions are running?
 
-**Assistant:** Listing all active sessions.
+**Assistant:** Listing active sessions.
 
 ```bash
 $ .opencode/skills/kocao-agent/scripts/agent-list.sh
@@ -152,17 +151,13 @@ $ .opencode/skills/kocao-agent/scripts/agent-list.sh
 }
 ```
 
-**Assistant:** There are 2 active sessions:
-1. `ws-a1b2c3d4` (codex) — the one we started for README review
-2. `ws-z9y8x7w6` (opencode) — running API tests, started 30 minutes ago
-
 ---
 
-## Scene 6: Stop the agent
+## Scene 6: Stop the session
 
-**User:** The codex agent is done. Stop it.
+**User:** That session is done. Stop it.
 
-**Assistant:** Stopping the codex session.
+**Assistant:** Stopping the workspace session.
 
 ```bash
 $ .opencode/skills/kocao-agent/scripts/agent-stop.sh ws-a1b2c3d4
@@ -175,22 +170,15 @@ $ .opencode/skills/kocao-agent/scripts/agent-stop.sh ws-a1b2c3d4
 }
 ```
 
-**Assistant:** Session `ws-a1b2c3d4` has been stopped. The codex agent's work
-(PR #47) is preserved in GitHub.
-
 ---
 
 ## Summary
 
-This demo showed the full lifecycle of managing a remote coding agent:
+This demo covered the full lifecycle:
 
-1. **Start** — Created a codex agent session on the cluster
-2. **Exec** — Sent a review task to the running agent
-3. **Status** — Checked the agent's current phase and run info
-4. **Logs** — Viewed the agent's output and progress
-5. **List** — Saw all active agent sessions
-6. **Stop** — Terminated the completed session
-
-The `kocao-agent` skill provides an AI assistant with full control over remote
-coding agents, enabling multi-agent workflows where tasks are distributed
-across specialized agents running in isolated Kubernetes pods.
+1. create a remote workspace session
+2. send a task through the optional exec endpoint
+3. inspect session status
+4. review logs
+5. list active sessions
+6. stop the finished session


### PR DESCRIPTION
## Summary

Adds an OpenCode/Claude Code skill at `.opencode/skills/kocao-agent/` that enables AI coding tools to manage remote Kocao sandbox agents via the `kocao agent` CLI.

### What's Included

- **SKILL.md** — trigger descriptions, 7 workflows, usage examples
- **6 wrapper scripts** — `agent-list.sh`, `agent-start.sh`, `agent-stop.sh`, `agent-logs.sh`, `agent-exec.sh`, `agent-status.sh`
- **`scripts/common.sh`** — shared helpers for dependency checks, HTTP requests, error formatting
- **`reference/agents.md`** — supported agents catalog, env vars, prerequisites, troubleshooting

### Key Design

- Skill wraps the `kocao` CLI (not direct API calls)
- All scripts default to `--output json` for AI parsability
- Natural language triggers: "start an agent on the cluster", "send a task to a remote agent", etc.
- Multi-agent workflow documentation
- All scripts pass `bash -n` and `shellcheck`

### Demo

See `docs/demos/agent-skill-remote-management.md` for a showboat walkthrough.

### Dependencies

Depends on `007-02_cli-agent-management` (the CLI commands this skill wraps).

### Change

Ito change: `007-03_agent-management-skill` (module 007: sandbox-agent-platform)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added kocao-agent CLI tooling for managing remote workspace sessions: start, exec/send prompts, status, logs (streaming), list, and stop.

* **Documentation**
  * Added skill docs, reference guide, and an end-to-end demo showing the full session lifecycle.

* **Chores**
  * Added issue-tracking records capturing epics and tasks for E2E validation and a token-sync sidecar follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->